### PR TITLE
Update CONTIBUTING to enable GitHub actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,6 @@
 name: Go
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,9 @@ The codebase is maintained using the "contributor workflow" where everyone witho
 To contribute a patch, make sure you follow this workflow:
 
 1. Fork repository
-2. Create topic branch
-3. Commit patches
+2. Enable GitHub actions to run in your fork
+3. Create topic branch
+4. Commit patches
 
 ### Commit Messages
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This change both enables the running of GitHub Actions for PRs and Push
events, and adds some documentation on the contributing doc to enable
github actions on the contributor's fork.
