### PR TITLE
api: Add Timeout duration field to Config

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -53,6 +53,7 @@ type AuthWriter interface {
 
 // NewAPI initializes the API clients from an API config that it receives
 func NewAPI(c Config) (*API, error) {
+	c.fillDefaults()
 	if err := c.Validate(); err != nil {
 		return nil, err
 	}
@@ -61,7 +62,16 @@ func NewAPI(c Config) (*API, error) {
 		SkipTLSVerify:   c.SkipTLSVerify,
 		ErrorDevice:     c.ErrorDevice,
 		VerboseSettings: c.VerboseSettings,
+		Timeout:         c.Timeout,
 	})
+
+	// Sadly, all the clinet parameters take the DefaultTimeout from the runtime
+	// client if not specified in the call as a query parameter, modifying this
+	// value effectively affects all of the related clients.
+	runtimeclient.DefaultTimeout = c.Timeout
+
+	// Also sets the client Timeout value
+	c.Client.Timeout = c.Timeout
 
 	rest, err := newRestClient(c)
 	if err != nil {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -65,7 +65,7 @@ func NewAPI(c Config) (*API, error) {
 		Timeout:         c.Timeout,
 	})
 
-	// Sadly, all the clinet parameters take the DefaultTimeout from the runtime
+	// Sadly, all the client parameters take the DefaultTimeout from the runtime
 	// client if not specified in the call as a query parameter, modifying this
 	// value effectively affects all of the related clients.
 	runtimeclient.DefaultTimeout = c.Timeout

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
 )
@@ -45,10 +46,13 @@ type Config struct {
 	ErrorDevice io.Writer
 
 	VerboseSettings
+
+	// Timeout for all of the API calls performed through the API structure.
+	Timeout time.Duration
 }
 
 // Validate returns an error if the config is invalid
-func (c Config) Validate() error {
+func (c *Config) Validate() error {
 	var err = new(multierror.Error)
 	if c.Client == nil {
 		err = multierror.Append(err, errors.New("api: client cannot be empty"))
@@ -62,6 +66,12 @@ func (c Config) Validate() error {
 	err = multierror.Append(err, c.VerboseSettings.Validate())
 
 	return err.ErrorOrNil()
+}
+
+func (c *Config) fillDefaults() {
+	if c.Timeout.Nanoseconds() <= 0 {
+		c.Timeout = DefaultTimeout
+	}
 }
 
 // VerboseSettings define the behaviour of verbosity.

--- a/pkg/api/transport_errcatch.go
+++ b/pkg/api/transport_errcatch.go
@@ -50,7 +50,7 @@ type ErrCatchTransport struct {
 // of the current request.
 func (e *ErrCatchTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if e.rt == nil {
-		newDefaultTransport()
+		newDefaultTransport(0)
 	}
 
 	res, err := e.rt.RoundTrip(req)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a Timeout field of `time.Duration` to the `api.Config` structure,
allowing users to set the Timeout value for all API calls.
It relies on modifying the runtime/client package DefaultTimeout value,
net.Dialer and http.Client Timeout values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Not able to specify client timeouts.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
