### PR TITLE
 test: Fix flaky 'TestPoolAdd/Add_succeeds' test 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,8 @@ require (
 	github.com/go-openapi/swag v0.19.6
 	github.com/go-openapi/validate v0.19.5
 	github.com/hashicorp/go-multierror v1.0.0
-	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0
-	golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e // indirect
 )
 
 replace sourcegraph.com/sourcegraph/go-diff v0.5.1 => github.com/sourcegraph/go-diff v0.5.1

--- a/pkg/sync/pool/pool_test.go
+++ b/pkg/sync/pool/pool_test.go
@@ -161,9 +161,12 @@ func TestPoolAdd(t *testing.T) {
 		err    error
 	}{
 		{
+			// To avoid test flakiness, the behaviour of this test is as follows:
+			// The queue has 3 buffered spots and 2 work items are sent. We're simulating 
+			// that 2 items are consumed immediately via `limitConsumption` to 2.
 			name: "Add succeeds",
 			fields: fields{
-				queue: make(chan Validator),
+				queue: make(chan Validator, 3),
 				signals: Signals{
 					Added: make(chan struct{}),
 				},
@@ -176,6 +179,7 @@ func TestPoolAdd(t *testing.T) {
 				work:          generateWork(2),
 				consumeQueue:  true,
 				consumeSignal: true,
+				limitConsumption: 2,
 			},
 			want: want{
 				queueContents: generateWork(2),

--- a/pkg/sync/pool/pool_test.go
+++ b/pkg/sync/pool/pool_test.go
@@ -162,7 +162,7 @@ func TestPoolAdd(t *testing.T) {
 	}{
 		{
 			// To avoid test flakiness, the behaviour of this test is as follows:
-			// The queue has 3 buffered spots and 2 work items are sent. We're simulating 
+			// The queue has 3 buffered spots and 2 work items are sent. We're simulating
 			// that 2 items are consumed immediately via `limitConsumption` to 2.
 			name: "Add succeeds",
 			fields: fields{
@@ -176,9 +176,9 @@ func TestPoolAdd(t *testing.T) {
 				timeouts: testTimeout,
 			},
 			args: args{
-				work:          generateWork(2),
-				consumeQueue:  true,
-				consumeSignal: true,
+				work:             generateWork(2),
+				consumeQueue:     true,
+				consumeSignal:    true,
 				limitConsumption: 2,
 			},
 			want: want{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes an issue where the  "TestPoolAdd/Add_succeeds" test sometimes failed when running it through GitHub actions with the following error:

```
--- FAIL: TestPoolAdd (0.02s)
    --- FAIL: TestPoolAdd/Add_succeeds (0.01s)
##[error]        pool_test.go:288: Pool.Add() = [0x7678c8], want {[] [0x7678c8 0x7678c8] [{} {}]}
##[error]        pool_test.go:291: Pool.Add() error = pool: failed adding work, queue full, want <nil>
##[error]        pool_test.go:301: Pool.queue = [0x7678c8], want [0x7678c8 0x7678c8]
##[error]        pool_test.go:305: Pool.signals.added = [{}], want [{} {}]
```

**Note: While I was not able to reproduce this error again, the following was done to avoid flakiness:**
The behaviour of this test is as follows:
- The queue has 3 buffered spots 
- 2 work items are sent. 
- We're simulating that 2 items are consumed immediately via `limitConsumption` to 2.

## Related Issues
Closes: https://github.com/elastic/cloud-sdk-go/issues/36

## Motivation and Context
No one likes flaky tests :)

## How Has This Been Tested?
By running the test multiple times.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
