### PR TITLE
api: Add CloudClientRuntime client.Runtime wrapper

### DIFF
--- a/pkg/api/client_runtime.go
+++ b/pkg/api/client_runtime.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/go-openapi/runtime"
+	runtimeclient "github.com/go-openapi/runtime/client"
+)
+
+const (
+	// RegionPrefix is used when a Region is passed as part of the API config.
+	RegionPrefix = "/api/v1/regions/%s"
+
+	// RegionlessPrefix is used when no region is specified, assumed target is
+	// most likely an ECE installation or a non federated one.
+	RegionlessPrefix = "/api/v1"
+)
+
+// NewCloudClientRuntime creates a CloudClientRuntime from the config. Using
+// the configured region (if any) to instantiate two different client.Runtime.
+// If there's no region specified in the config then both are regionless.
+func NewCloudClientRuntime(c Config) (*CloudClientRuntime, error) {
+	u, err := url.Parse(c.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	var basepath = RegionlessPrefix
+	if c.Region != "" {
+		basepath = fmt.Sprintf(RegionPrefix, c.Region)
+	}
+
+	// Additional consumers and producers that are needed for parts of the SDK
+	// to work correctly
+	rr := AddTypeConsumers(runtimeclient.NewWithClient(
+		u.Host, basepath, []string{u.Scheme}, c.Client,
+	))
+
+	r := AddTypeConsumers(runtimeclient.NewWithClient(
+		u.Host, RegionlessPrefix, []string{u.Scheme}, c.Client,
+	))
+
+	return &CloudClientRuntime{
+		regionRuntime: rr,
+		runtime:       r,
+	}, nil
+}
+
+// CloudClientRuntime wraps runtimeclient.Runtime to allow operations to use a
+// transport depending on the operation which is being performed.
+type CloudClientRuntime struct {
+	regionRuntime *runtimeclient.Runtime
+	runtime       *runtimeclient.Runtime
+}
+
+// Submit calls either the regionRuntime or the regionless runtime depending on
+// which operation is being performed. Any API call to /deployments will use a
+// regionless runtime while all others will use a region (if specified).
+func (r *CloudClientRuntime) Submit(op *runtime.ClientOperation) (interface{}, error) {
+	if strings.HasPrefix(op.PathPattern, "/deployments") {
+		return r.runtime.Submit(op)
+	}
+	return r.regionRuntime.Submit(op)
+}

--- a/pkg/api/client_runtime.go
+++ b/pkg/api/client_runtime.go
@@ -76,8 +76,12 @@ type CloudClientRuntime struct {
 // which operation is being performed. Any API call to /deployments will use a
 // regionless runtime while all others will use a region (if specified).
 func (r *CloudClientRuntime) Submit(op *runtime.ClientOperation) (interface{}, error) {
+	return r.getRuntime(op).Submit(op)
+}
+
+func (r *CloudClientRuntime) getRuntime(op *runtime.ClientOperation) *runtimeclient.Runtime {
 	if strings.HasPrefix(op.PathPattern, "/deployments") {
-		return r.runtime.Submit(op)
+		return r.runtime
 	}
-	return r.regionRuntime.Submit(op)
+	return r.regionRuntime
 }

--- a/pkg/api/client_runtime_test.go
+++ b/pkg/api/client_runtime_test.go
@@ -1,0 +1,188 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	runtimeclient "github.com/go-openapi/runtime/client"
+)
+
+func TestNewCloudClientRuntime(t *testing.T) {
+	type args struct {
+		c Config
+	}
+	tests := []struct {
+		name string
+		args args
+		want *CloudClientRuntime
+		err  error
+	}{
+		{
+			name: "returns an error when it can't parse the host",
+			args: args{c: Config{
+				Host: " https://cloud.elastic.co",
+			}},
+			err: &url.Error{
+				Op:  "parse",
+				URL: " https://cloud.elastic.co",
+				Err: errors.New("first path segment in URL cannot contain colon"),
+			},
+		},
+		{
+			name: "when region is specified the structure has two different runtimes",
+			args: args{c: Config{
+				Host:   "https://cloud.elastic.co",
+				Region: "us-east-1",
+			}},
+			want: &CloudClientRuntime{
+				regionRuntime: AddTypeConsumers(runtimeclient.NewWithClient(
+					"cloud.elastic.co",
+					fmt.Sprintf(RegionPrefix, "us-east-1"),
+					[]string{"https"}, nil,
+				)),
+				runtime: AddTypeConsumers(runtimeclient.NewWithClient(
+					"cloud.elastic.co",
+					RegionlessPrefix,
+					[]string{"https"}, nil,
+				)),
+			},
+		},
+		{
+			name: "when region is specified the structure has two equal runtimes",
+			args: args{c: Config{
+				Host: "https://cloud.elastic.co",
+			}},
+			want: &CloudClientRuntime{
+				regionRuntime: &runtimeclient.Runtime{
+					Host:     "cloud.elastic.co",
+					BasePath: RegionlessPrefix,
+				},
+				runtime: &runtimeclient.Runtime{
+					Host:     "cloud.elastic.co",
+					BasePath: RegionlessPrefix,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewCloudClientRuntime(tt.args.c)
+			if !reflect.DeepEqual(tt.err, err) {
+				t.Errorf("NewCloudClientRuntime() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if tt.want != nil && got != nil {
+				if tt.want.regionRuntime.BasePath != got.regionRuntime.BasePath {
+					t.Errorf("NewCloudClientRuntime() regionRuntime = %v, want %v",
+						got.regionRuntime.BasePath, tt.want.regionRuntime.BasePath,
+					)
+				}
+				if tt.want.runtime.BasePath != got.runtime.BasePath {
+					t.Errorf("NewCloudClientRuntime() runtime = %v, want %v",
+						got.runtime.BasePath, tt.want.runtime.BasePath,
+					)
+				}
+				if tt.want.regionRuntime.Host != got.regionRuntime.Host {
+					t.Errorf("NewCloudClientRuntime() regionRuntime = %v, want %v",
+						got.regionRuntime.Host, tt.want.regionRuntime.Host,
+					)
+				}
+				if tt.want.runtime.Host != got.runtime.Host {
+					t.Errorf("NewCloudClientRuntime() runtime = %v, want %v",
+						got.runtime.Host, tt.want.runtime.Host,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestCloudClientRuntime_getRuntime(t *testing.T) {
+	type fields struct {
+		regionRuntime *runtimeclient.Runtime
+		runtime       *runtimeclient.Runtime
+	}
+	type args struct {
+		op *runtime.ClientOperation
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *runtimeclient.Runtime
+	}{
+		{
+			name: "/deployment operation uses the regionless path",
+			fields: fields{
+				regionRuntime: AddTypeConsumers(runtimeclient.NewWithClient(
+					"cloud.elastic.co",
+					fmt.Sprintf(RegionPrefix, "us-east-1"),
+					[]string{"https"}, nil,
+				)),
+				runtime: AddTypeConsumers(runtimeclient.NewWithClient(
+					"cloud.elastic.co",
+					RegionlessPrefix,
+					[]string{"https"}, nil,
+				)),
+			},
+			args: args{op: &runtime.ClientOperation{
+				PathPattern: "/deployments",
+			}},
+			want: &runtimeclient.Runtime{BasePath: "/api/v1"},
+		},
+		{
+			name: "/platform operation uses the regioned path",
+			fields: fields{
+				regionRuntime: AddTypeConsumers(runtimeclient.NewWithClient(
+					"cloud.elastic.co",
+					fmt.Sprintf(RegionPrefix, "us-east-1"),
+					[]string{"https"}, nil,
+				)),
+				runtime: AddTypeConsumers(runtimeclient.NewWithClient(
+					"cloud.elastic.co",
+					RegionlessPrefix,
+					[]string{"https"}, nil,
+				)),
+			},
+			args: args{op: &runtime.ClientOperation{
+				PathPattern: "/platform",
+			}},
+			want: &runtimeclient.Runtime{BasePath: "/api/v1/regions/us-east-1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &CloudClientRuntime{
+				regionRuntime: tt.fields.regionRuntime,
+				runtime:       tt.fields.runtime,
+			}
+			got := r.getRuntime(tt.args.op)
+			if tt.want.BasePath != got.BasePath {
+				t.Errorf("NewCloudClientRuntime() = %v, want %v",
+					got.BasePath, tt.want.BasePath,
+				)
+			}
+		})
+	}
+}

--- a/pkg/api/client_runtime_test.go
+++ b/pkg/api/client_runtime_test.go
@@ -69,7 +69,7 @@ func TestNewCloudClientRuntime(t *testing.T) {
 			},
 		},
 		{
-			name: "when region is specified the structure has two equal runtimes",
+			name: "when region is not specified the structure has two equal runtimes",
 			args: args{c: Config{
 				Host: "https://cloud.elastic.co",
 			}},


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new structure which implements runtime/client.ClientTransport
and allows predefined rules to call a regionless or region prefixed URL
API client.

This change is necessary since the `/deployments` path does not work
with the region interpolated in the URL.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`/deployments` API doesn't work with interpolated URL paths.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

