### PR TITLE
add the soteria logging wrarppers,utils and assertions

### DIFF
--- a/pkg/logging/assert.go
+++ b/pkg/logging/assert.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package logging
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// AssertLoggedMessages asserts the logged messages dispatched by a mocked logger
+func AssertLoggedMessages(t *testing.T, mockLogger Dispatcher, wantMessages []string) {
+	if mockLogger == nil {
+		return
+	}
+
+	mockDispatcher := mockLogger.(*MockDispatcher)
+	messagesLogged := mockDispatcher.GetDispatchedMessages()
+	if len(wantMessages) > 0 && len(messagesLogged) == 0 {
+		if !reflect.DeepEqual(wantMessages, messagesLogged) {
+			t.Errorf("%s expected logged messages %v but got \n\nnone", t.Name(),
+				strings.Join(wantMessages, "\n"))
+		}
+	}
+
+	if len(wantMessages) == 0 && len(messagesLogged) > 0 {
+		if !reflect.DeepEqual(wantMessages, messagesLogged) {
+			t.Errorf("%s expected no logged messages but got \n\n%v", t.Name(),
+				strings.Join(messagesLogged, "\n"))
+		}
+	}
+	if len(wantMessages) > 0 && len(messagesLogged) > 0 {
+		if len(wantMessages) < len(messagesLogged) {
+			t.Errorf("%s more messages logged [%d] than expected [%d] \n\n additional messages logged:\n%+v",
+				t.Name(),
+				len(messagesLogged),
+				len(wantMessages),
+				strings.Join(messagesLogged[len(wantMessages):], "\n"))
+		}
+		for index, m := range wantMessages {
+			if len(messagesLogged) <= index {
+				t.Errorf("%s expected logged message [%d] \n%v \n\nbut got none",
+					t.Name(),
+					index,
+					m)
+				return
+			}
+			if messagesLogged[index] != m {
+				t.Errorf("%s expected logged message [%d] \n%v \n\nbut got \n\n%v",
+					t.Name(),
+					index,
+					m,
+					messagesLogged[index])
+			}
+		}
+	}
+}

--- a/pkg/logging/ecs.go
+++ b/pkg/logging/ecs.go
@@ -33,7 +33,7 @@ type LogMessage struct {
 	Labels    map[string]string `json:"labels,omitempty"`
 	Message   string            `json:"message,omitempty"`
 	Agent     Agent             `json:"agent,omitempty"`
-	Error     Error             `json:"error,omitempty"`
+	Error     Err               `json:"error,omitempty"`
 	HTTP      HTTP              `json:"http,omitempty"`
 	Log       Log               `json:"log,omitempty"`
 	ECS       ECS               `json:"ecs,omitempty"`
@@ -76,7 +76,7 @@ func (msg LogMessage) WithAgent(agent Agent) LogMessage {
 }
 
 // WithError sets the agent object field and returns the message itself
-func (msg LogMessage) WithError(err Error) LogMessage {
+func (msg LogMessage) WithError(err Err) LogMessage {
 	msg.Error = err
 	return msg
 }
@@ -131,34 +131,34 @@ func (agent Agent) WithEphemeralID(id string) Agent {
 	return agent
 }
 
-// Error is the structure of an error
+// Err is the structure of an error
 // These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error.
-type Error struct {
+type Err struct {
 	Message string `json:"message,omitempty"`
 	ID      string `json:"id,omitempty"`
 	Code    string `json:"code,omitempty"`
 }
 
 // NewError creates a new Error and properly initializes all required fields
-func NewError() Error {
-	err := Error{}
+func NewError() Err {
+	err := Err{}
 	return err
 }
 
 // WithMessage sets the message field and returns the error itself
-func (err Error) WithMessage(msg string) Error {
+func (err Err) WithMessage(msg string) Err {
 	err.Message = msg
 	return err
 }
 
 // WithID sets the ID field and returns the error itself
-func (err Error) WithID(id string) Error {
+func (err Err) WithID(id string) Err {
 	err.ID = id
 	return err
 }
 
 // WithCode sets the Code field and returns the error itself
-func (err Error) WithCode(code string) Error {
+func (err Err) WithCode(code string) Err {
 	err.Code = code
 	return err
 }

--- a/pkg/logging/ecs_test.go
+++ b/pkg/logging/ecs_test.go
@@ -351,7 +351,7 @@ func TestNewLogMessage(t *testing.T) {
 		name          string
 		logMsg        LogMessage
 		wantedAgent   Agent
-		wantedError   Error
+		wantedError   Err
 		wantedLog     Log
 		wantedHTTP    HTTP
 		wantedMessage string

--- a/pkg/logging/standardoutput/standard_output_logger_test.go
+++ b/pkg/logging/standardoutput/standard_output_logger_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/fatih/color"
 
+	"github.com/elastic/cloud-sdk-go/pkg/logging"
 	loggingdecorator "github.com/elastic/cloud-sdk-go/pkg/logging/decorator"
 )
 
@@ -171,3 +172,229 @@ func Test_levelColor(t *testing.T) {
 		})
 	}
 }
+
+func TestDebug(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{
+			name: "Log debug should properly create a debug message",
+			msg:  "Log message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logMessage := Debug(tt.msg)
+
+			if logMessage.Message != tt.msg {
+				t.Errorf("Debug() logMessage.Message expected %s actual %s", tt.msg, logMessage.Message)
+				return
+			}
+			if logMessage.Log.Level != "DEBUG" {
+				t.Errorf("Debug() logMessage.Log.Level expected %s actual %s", "DEBUG", logMessage.Log.Level)
+				return
+			}
+			if !reflect.DeepEqual(logMessage.Agent, agent) {
+				t.Errorf("Debug() logMessage.Agent expected %v actual %v", agent, logMessage.Agent)
+				return
+			}
+		})
+	}
+}
+
+func TestInfo(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{
+			name: "Log info should properly create a info message",
+			msg:  "Log message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logMessage := Info(tt.msg)
+
+			if logMessage.Message != tt.msg {
+				t.Errorf("Info() logMessage.Message expected %s actual %s", tt.msg, logMessage.Message)
+				return
+			}
+			if logMessage.Log.Level != "INFO" {
+				t.Errorf("Info() logMessage.Log.Level expected %s actual %s", "INFO", logMessage.Log.Level)
+				return
+			}
+			if !reflect.DeepEqual(logMessage.Agent, agent) {
+				t.Errorf("Info() logMessage.Agent expected %v actual %v", agent, logMessage.Agent)
+				return
+			}
+		})
+	}
+}
+
+func TestWarn(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{
+			name: "Log warn should properly create a warn message",
+			msg:  "Log message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logMessage := Warn(tt.msg)
+
+			if logMessage.Message != tt.msg {
+				t.Errorf("Warn() logMessage.Message expected %s actual %s", tt.msg, logMessage.Message)
+				return
+			}
+			if logMessage.Log.Level != "WARN" {
+				t.Errorf("Warn() logMessage.Log.Level expected %s actual %s", "WARN", logMessage.Log.Level)
+				return
+			}
+			if !reflect.DeepEqual(logMessage.Agent, agent) {
+				t.Errorf("Warn() logMessage.Agent expected %v actual %v", agent, logMessage.Agent)
+				return
+			}
+		})
+	}
+}
+
+func TestError(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{
+			name: "Log error should properly create an error message",
+			msg:  "Log message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logMessage := Error(tt.msg)
+
+			if logMessage.Message != tt.msg {
+				t.Errorf("Error() logMessage.Message expected %s actual %s", tt.msg, logMessage.Message)
+				return
+			}
+			if logMessage.Error.Message != tt.msg {
+				t.Errorf("Error() logMessage.Message expected %s actual %s", tt.msg, logMessage.Message)
+				return
+			}
+			if logMessage.Log.Level != "ERROR" {
+				t.Errorf("Error() logMessage.Log.Level expected %s actual %s", "ERROR", logMessage.Log.Level)
+				return
+			}
+			if !reflect.DeepEqual(logMessage.Agent, agent) {
+				t.Errorf("Error() logMessage.Agent expected %v actual %v", agent, logMessage.Agent)
+				return
+			}
+		})
+	}
+}
+
+func TestLevel(t *testing.T) {
+	tests := []struct {
+		name        string
+		level       string
+		expLoglevel logging.LogLevel
+	}{
+		{
+			name:        "should return logging.TRACE",
+			level:       TRACE,
+			expLoglevel: logging.TRACE,
+		},
+		{
+			name:        "should return logging.DEBUG",
+			level:       DEBUG,
+			expLoglevel: logging.DEBUG,
+		},
+		{
+			name:        "should return logging.INFO",
+			level:       INFO,
+			expLoglevel: logging.INFO,
+		},
+		{
+			name:        "should return logging.WARNING",
+			level:       WARN,
+			expLoglevel: logging.WARNING,
+		},
+		{
+			name:        "should return logging.ERROR",
+			level:       ERROR,
+			expLoglevel: logging.ERROR,
+		},
+		{
+			name:        "should return the default level",
+			level:       "UNKNOWN",
+			expLoglevel: logging.INFO,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.expLoglevel != Level(tt.level) {
+				t.Errorf("Level() expected %v but actual %s", tt.expLoglevel, tt.level)
+				return
+			}
+		})
+	}
+}
+
+func TestStandardLogger_Log(t *testing.T) {
+	tests := []struct {
+		name    string
+		logger  StandardLogger
+		message string
+	}{
+		{
+			name:    "should log message",
+			logger:  StandardLogger{Dispatcher: logging.NewMockDispatcher()},
+			message: "test message",
+		},
+		{
+			name:   "should not log message",
+			logger: StandardLogger{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.logger.Log(Info(tt.message))
+			logging.AssertLoggedMessages(t, tt.logger.Dispatcher, []string{tt.message})
+		})
+	}
+}
+
+func TestStandardLogger_LogIf(t *testing.T) {
+	tests := []struct {
+		name        string
+		logger      StandardLogger
+		message     string
+		shouldLog   bool
+		expMessages []string
+	}{
+		{
+			name:        "should log message",
+			logger:      StandardLogger{Dispatcher: logging.NewMockDispatcher()},
+			message:     "test message",
+			shouldLog:   true,
+			expMessages: []string{"test message"},
+		},
+		{
+			name:    "should not log message",
+			logger:  StandardLogger{Dispatcher: logging.NewMockDispatcher()},
+			message: "test message",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.logger.LogIf(Info(tt.message), tt.shouldLog)
+			logging.AssertLoggedMessages(t, tt.logger.Dispatcher, tt.expMessages)
+		})
+	}
+}
+
+var agent = logging.NewAgent()


### PR DESCRIPTION
## Description
This PR adds the following

- a convenient assert method to assert expected logged messages in testing
- a standard logger that wraps dispatcher and makes logging more readable
- as a side-effect the ecs.Error struct renamed to ecs.Err to avoid conflicts with the standardlogger.Error function introduced

## Motivation and Context
Make logging even easier

## How Has This Been Tested?
UTs

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
