### PR TITLE
bump golang-ci linter version to 1.22.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,8 @@ linters:
     - gochecknoinits
     - scopelint
     - funlen
-
+    - wsl
+    - gomnd
 linters-settings:
   govet:
     check-shadowing: false
@@ -54,7 +55,7 @@ issues:
         - errcheck
         - dupl
         - gosec
-
+        - gocognit
 
 output:
   format: tab

--- a/build/Makefile.deps
+++ b/build/Makefile.deps
@@ -9,7 +9,7 @@ ifndef SKIP_DEPCHECK
 	@ $(GOBIN)/gobin github.com/go-swagger/go-swagger/cmd/swagger@v0.19.0
 	@ $(GOBIN)/gobin github.com/elastic/go-licenser@v0.3.0
 	@ $(GOBIN)/gobin golang.org/x/lint/golint
-	@ curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.19.0
+	@ curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOBIN) v1.22.2
 	@ echo "-> Done."
 endif
 


### PR DESCRIPTION
## Description
This PR 

- bumps golang-ci linter version to 1.22.2
- excludes a few linters introduced from tests and source files
