### PR TITLE
api: /deployment/{id}/notes should use region path

### DIFF
--- a/pkg/api/client_runtime.go
+++ b/pkg/api/client_runtime.go
@@ -80,7 +80,9 @@ func (r *CloudClientRuntime) Submit(op *runtime.ClientOperation) (interface{}, e
 }
 
 func (r *CloudClientRuntime) getRuntime(op *runtime.ClientOperation) *runtimeclient.Runtime {
-	if strings.HasPrefix(op.PathPattern, "/deployments") {
+	var isDeployment = strings.HasPrefix(op.PathPattern, "/deployments")
+	var notDeploymentNotes = !strings.Contains(op.PathPattern, "/note")
+	if isDeployment && notDeploymentNotes {
 		return r.runtime
 	}
 	return r.regionRuntime

--- a/pkg/api/client_runtime_test.go
+++ b/pkg/api/client_runtime_test.go
@@ -152,6 +152,25 @@ func TestCloudClientRuntime_getRuntime(t *testing.T) {
 			want: &runtimeclient.Runtime{BasePath: "/api/v1"},
 		},
 		{
+			name: "/deployment/someid/notes operation uses the region path",
+			fields: fields{
+				regionRuntime: AddTypeConsumers(runtimeclient.NewWithClient(
+					"cloud.elastic.co",
+					fmt.Sprintf(RegionPrefix, "us-east-1"),
+					[]string{"https"}, nil,
+				)),
+				runtime: AddTypeConsumers(runtimeclient.NewWithClient(
+					"cloud.elastic.co",
+					RegionlessPrefix,
+					[]string{"https"}, nil,
+				)),
+			},
+			args: args{op: &runtime.ClientOperation{
+				PathPattern: "/deployments/someid/notes",
+			}},
+			want: &runtimeclient.Runtime{BasePath: "/api/v1/regions/us-east-1"},
+		},
+		{
 			name: "/platform operation uses the regioned path",
 			fields: fields{
 				regionRuntime: AddTypeConsumers(runtimeclient.NewWithClient(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Changes the `CloudClientRuntime` to use the region interpolated path on
deployment notes commands

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
#46 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Deployment notes do not work with a regionless path.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
