### PR TITLE
build: Add Go module cache for GitHub actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,14 @@ jobs:
         go-version: 1.13
       id: go
 
+    - name: Cache Go Modules
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,9 @@ jobs:
         go-version: 1.13
       id: go
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
     - name: Cache Go Modules
       uses: actions/cache@v1
       with:
@@ -22,9 +25,6 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
 
     - name: Get dependencies
       run: make vendor


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds the cache action to all workflows so that the Go modules can be
pre-cached

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Cached dependencies to speed up the builds
