### PR TITLE
feat(cmdutil): add resource closer logger.

### DIFF
--- a/pkg/util/cmdutil/close.go
+++ b/pkg/util/cmdutil/close.go
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdutil
+
+import (
+	"fmt"
+	"io"
+)
+
+// ErrorLoggerFunc is the callback for logging error
+type ErrorLoggerFunc func(err error)
+
+// CloseResource try to close the resource and log error if occurs.
+func CloseResource(closer io.Closer, logger ErrorLoggerFunc) {
+	// Check if closer is nil
+	if closer == nil {
+		return
+	}
+	// Try to close the resource
+	if err := closer.Close(); err != nil {
+		if logger != nil {
+			// Wrap error
+			logger(fmt.Errorf("unable to close resource: %w", err))
+		}
+	}
+}

--- a/pkg/util/cmdutil/close_test.go
+++ b/pkg/util/cmdutil/close_test.go
@@ -39,29 +39,39 @@ func (m *mockCloser) Close() error {
 
 // -----------------------------------------------------------------------------
 
-func TestCloser_CloseResource(t *testing.T) {
-	testCases := []struct {
-		desc    string
-		closer  io.Closer
-		wantErr bool
-	}{
-		{
-			desc:    "closer nil",
-			closer:  nil,
-			wantErr: false,
-		},
-		{
-			desc:    "closer error",
-			closer:  &mockCloser{raiseError: true},
-			wantErr: true,
-		},
-		{
-			desc:    "success",
-			closer:  &mockCloser{raiseError: false},
-			wantErr: false,
-		},
+var closerLoggerTestCases = []struct {
+	desc    string
+	closer  io.Closer
+	wantErr bool
+}{
+	{
+		desc:    "closer nil",
+		closer:  nil,
+		wantErr: false,
+	},
+	{
+		desc:    "closer error",
+		closer:  &mockCloser{raiseError: true},
+		wantErr: true,
+	},
+	{
+		desc:    "success",
+		closer:  &mockCloser{raiseError: false},
+		wantErr: false,
+	},
+}
+
+func TestCloser_CloseResource_NilLogger(t *testing.T) {
+	for _, tC := range closerLoggerTestCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			CloseResource(tC.closer, nil)
+			// Nothing to expect
+		})
 	}
-	for _, tC := range testCases {
+}
+
+func TestCloser_CloseResource(t *testing.T) {
+	for _, tC := range closerLoggerTestCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			CloseResource(tC.closer, func(err error) {
 				if tC.wantErr != (err != nil) {

--- a/pkg/util/cmdutil/close_test.go
+++ b/pkg/util/cmdutil/close_test.go
@@ -1,0 +1,73 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cmdutil
+
+import (
+	"fmt"
+	"io"
+	"testing"
+)
+
+// -----------------------------------------------------------------------------
+type mockCloser struct {
+	raiseError bool
+}
+
+func (m *mockCloser) Close() error {
+	if m.raiseError {
+		return fmt.Errorf("foo")
+	}
+
+	// No error
+	return nil
+}
+
+// -----------------------------------------------------------------------------
+
+func TestCloser_CloseResource(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		closer  io.Closer
+		wantErr bool
+	}{
+		{
+			desc:    "closer nil",
+			closer:  nil,
+			wantErr: false,
+		},
+		{
+			desc:    "closer error",
+			closer:  &mockCloser{raiseError: true},
+			wantErr: true,
+		},
+		{
+			desc:    "success",
+			closer:  &mockCloser{raiseError: false},
+			wantErr: false,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			CloseResource(tC.closer, func(err error) {
+				if tC.wantErr != (err != nil) {
+					t.Errorf("unexpected error occurs, got %v", err)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
# Context

In order to be able to log close resource error, I made this helper. It will be used to handle Vault connection close errors.

# Reference(s)

- https://github.com/elastic/soteria/pull/676