### PR TITLE
api: Add custom User-Agent transport

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -52,6 +52,7 @@ func NewAPI(c Config) (*API, error) {
 		ErrorDevice:     c.ErrorDevice,
 		VerboseSettings: c.VerboseSettings,
 		Timeout:         c.Timeout,
+		UserAgent:       c.UserAgent,
 	})
 
 	// Sadly, all the client parameters take the DefaultTimeout from the runtime

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -49,6 +49,9 @@ type Config struct {
 
 	// Timeout for all of the API calls performed through the API structure.
 	Timeout time.Duration
+
+	// UserAgent if specified, it sets the user agent on all outgoing requests.
+	UserAgent string
 }
 
 // Validate returns an error if the config is invalid
@@ -71,6 +74,10 @@ func (c *Config) Validate() error {
 func (c *Config) fillDefaults() {
 	if c.Timeout.Nanoseconds() <= 0 {
 		c.Timeout = DefaultTimeout
+	}
+
+	if c.UserAgent == "" {
+		c.UserAgent = DefaultUserAgent
 	}
 }
 

--- a/pkg/api/transport_user_agent.go
+++ b/pkg/api/transport_user_agent.go
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"net/http"
+)
+
+const userAgentHeader = "User-Agent"
+
+// DefaultUserAgent is used in UserAgentTransport when the agent is not set.
+// It defaults to the project name + the current committed version.
+var DefaultUserAgent = "cloud-sdk-go/" + Version
+
+// UserAgentTransport wraps an http.RoundTripper and adds an User-Agent header
+// to all requests  which are processed through the structure.
+type UserAgentTransport struct {
+	agent string
+	rt    http.RoundTripper
+}
+
+// NewUserAgentTransport initializes a new UserAgentTransport
+func NewUserAgentTransport(rt http.RoundTripper, agent string) *UserAgentTransport {
+	if agent == "" {
+		agent = DefaultUserAgent
+	}
+
+	if rt == nil {
+		rt = newDefaultTransport(0)
+	}
+
+	return &UserAgentTransport{
+		agent: agent,
+		rt:    rt,
+	}
+}
+
+// RoundTrip wraps http.DefaultTransport.RoundTrip to keep track
+// of the current request.
+func (ua *UserAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if ua.rt == nil {
+		ua.rt = newDefaultTransport(0)
+	}
+	if ua.agent == "" {
+		ua.agent = DefaultUserAgent
+	}
+
+	req.Header.Set(userAgentHeader, ua.agent)
+
+	return ua.rt.RoundTrip(req)
+}

--- a/pkg/api/transport_user_agent_test.go
+++ b/pkg/api/transport_user_agent_test.go
@@ -86,3 +86,36 @@ func TestUserAgentTransport_RoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestNewUserAgentTransport(t *testing.T) {
+	type args struct {
+		rt    http.RoundTripper
+		agent string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantAgent string
+	}{
+		{
+			name:      "new user agent with default settings",
+			wantAgent: DefaultUserAgent,
+		},
+		{
+			name:      "new user agent with a custom agent",
+			args:      args{agent: "someagent"},
+			wantAgent: "someagent",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewUserAgentTransport(tt.args.rt, tt.args.agent)
+			if got.agent != tt.wantAgent {
+				t.Errorf("NewUserAgentTransport() agent = %v, want %v", got.agent, tt.wantAgent)
+			}
+			if got.rt == nil {
+				t.Errorf("NewUserAgentTransport() rt is nil, something's not right")
+			}
+		})
+	}
+}

--- a/pkg/api/transport_user_agent_test.go
+++ b/pkg/api/transport_user_agent_test.go
@@ -1,0 +1,88 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+)
+
+func TestUserAgentTransport_RoundTrip(t *testing.T) {
+	var responseOK = mock.New200Response(mock.NewStringBody(`some`)).Response
+	type fields struct {
+		agent string
+		rt    http.RoundTripper
+	}
+	type args struct {
+		req *http.Request
+	}
+	tests := []struct {
+		name                string
+		fields              fields
+		args                args
+		want                *http.Response
+		err                 error
+		wantUserAgentHeader string
+	}{
+		{
+			name: "UserAgent is set to the default value",
+			fields: fields{rt: mock.NewRoundTripper(mock.New200Response(
+				mock.NewStringBody(`some`),
+			))},
+			args:                args{req: &http.Request{Header: http.Header{}}},
+			want:                &responseOK,
+			wantUserAgentHeader: DefaultUserAgent,
+		},
+		{
+			name: "UserAgent is set to a custom value",
+			fields: fields{
+				rt: mock.NewRoundTripper(mock.New200Response(
+					mock.NewStringBody(`some`),
+				)),
+				agent: "someagent/1.0.0",
+			},
+			args:                args{req: &http.Request{Header: http.Header{}}},
+			want:                &responseOK,
+			wantUserAgentHeader: "someagent/1.0.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ua := &UserAgentTransport{
+				agent: tt.fields.agent,
+				rt:    tt.fields.rt,
+			}
+			got, err := ua.RoundTrip(tt.args.req)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("UserAgentTransport.RoundTrip() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			defer got.Body.Close()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UserAgentTransport.RoundTrip() = %v, want %v", got, tt.want)
+			}
+			actualHeader := tt.args.req.Header.Get(userAgentHeader)
+			if actualHeader != tt.wantUserAgentHeader {
+				t.Errorf("UserAgentTransport.RoundTrip() UserHeader = %v, want %v", actualHeader, tt.wantUserAgentHeader)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new type `UserAgentTransport` which wraps an `http.RoundTripper`
modifying all of the requests that pass through the Transport and
setting the user agent either to the default value if not set, or to the
value that has been configured.

Adds a `UserAgent` property to `api.Config` so that it's easily
configurable for users using our SDK.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #75 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually and mocking ecctl:

```console
$ dev-cli deployment list --verbose
Using config file: /Users/marc/.ecctl/config.json
==================== Start of Request #0 ====================
POST /api/v1/users/auth/_login HTTP/1.1
Host: XXXX:12343
User-Agent: cloud-sdk-go/2.5.0
Content-Length: 78
Accept: application/json
Content-Type: application/json
Accept-Encoding: gzip

[...]
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
