### PR TITLE
api: Modify transport to handle Proxied responses

### DIFF
--- a/pkg/api/transport_errcatch.go
+++ b/pkg/api/transport_errcatch.go
@@ -18,6 +18,7 @@
 package api
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -27,6 +28,12 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+const (
+	contentType         = "Content-Type"
+	textHTMLContentType = "text/html"
+	jsonContentType     = "application/json"
 )
 
 // DefaultTransport can be used by clients which rely on the api.UnwrapError
@@ -68,8 +75,8 @@ func (e *ErrCatchTransport) RoundTrip(req *http.Request) (*http.Response, error)
 		// for the response to be marshaled to  JSON. Using the standard error
 		// definition and populating it with parts of the request so the error
 		// can be identified.
-		if strings.Contains(res.Header.Get("Content-Type"), "text/html") {
-			res.Header.Set("Content-Type", "application/json")
+		if strings.Contains(res.Header.Get(contentType), textHTMLContentType) {
+			res.Header.Set(contentType, jsonContentType)
 			res.Body = newProxyBody(req, res.StatusCode)
 		}
 	}
@@ -82,7 +89,7 @@ func newProxyBody(req *http.Request, code int) io.ReadCloser {
 		Errors: []*models.BasicFailedReplyElement{
 			{
 				Code:    ec.String(strconv.Itoa(code)),
-				Fields:  []string{req.Method + " " + req.URL.EscapedPath()},
+				Fields:  []string{fmt.Sprintf("%s %s", req.Method, req.URL.EscapedPath())},
 				Message: ec.String(http.StatusText(code)),
 			},
 		},


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Modifies the `ErrCatchTransport` type so that it handles the case when
`Content-Type` is `text/html`, the auto-generated client framework won't
be able to handle the proxied responses of that type since they're
contingent on the error response specified by the swagger definition,
thus anything with a `Content-Type` different than `application/json`
won't be handled and instead a cryptic error will be returned.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Any responses returned by the proxy and not by the actual Public API
which differ to the swagger definition, won't be handled properly and a cryptic
error is returned.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Before

```console
$ ecctl --config ess --region  us-east-1 platform deployment-template show aws-io-optimized
&{[]} (*models.BasicFailedReply) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interface
```

### After

```console
$ ecctl --config ess --region  us-east-1 platform deployment-template show aws-io-optimized
{
  "errors": [
    {
      "code": "404",
      "fields": [
        "GET /api/v1/regions/us-east-1/platform/configuration/templates/deployments/aws-io-optimized"
      ],
      "message": "Not Found"
    }
  ]
}
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
