### PR TITLE
multierror: Add package with Prefixed error type

### DIFF
--- a/pkg/multierror/doc.go
+++ b/pkg/multierror/doc.go
@@ -1,0 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package multierror can be leveraged as an opinionated to handle multiple
+// errors providing appropriate wrapping for them.
+package multierror

--- a/pkg/multierror/examples_test.go
+++ b/pkg/multierror/examples_test.go
@@ -1,0 +1,36 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package multierror
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+var output io.Writer = os.Stdout
+
+func ExamplePrefixed() {
+	err := NewPrefixed("config validation")
+	err = err.Append(errors.New("some validation error"))
+
+	if err.ErrorOrNil() != nil {
+		fmt.Fprintln(output, err)
+	}
+}

--- a/pkg/multierror/prefixed.go
+++ b/pkg/multierror/prefixed.go
@@ -59,6 +59,8 @@ func (p *Prefixed) ErrorOrNil() error {
 	return nil
 }
 
+// Error returns the stored slice of error formatted using a set FormatFunc or
+// multierror.ListFormatFunc when no FormatFunc is specified.
 func (p *Prefixed) Error() string {
 	if len(p.Errors) == 0 {
 		return ""

--- a/pkg/multierror/prefixed.go
+++ b/pkg/multierror/prefixed.go
@@ -1,0 +1,111 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package multierror
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// FormatFunc defines a format function which should format a slice of errors
+// into a string.
+type FormatFunc func(es []error) string
+
+// Prefixed is a multierror which will prefix the error output message with the
+// specified prefix.
+type Prefixed struct {
+	Prefix     string
+	Errors     []error
+	FormatFunc FormatFunc
+}
+
+// NewPrefixed creates a new pointer to Prefixed w
+func NewPrefixed(prefix string, errs ...error) *Prefixed {
+	return &Prefixed{Prefix: prefix, Errors: unpackErrors(errs...)}
+}
+
+// Append appends a number of errors to the current instance of Prefixed. It'll
+// unwrap any wrapped errors in the form of *Prefixed or *multierror.Error.
+func (p *Prefixed) Append(errs ...error) *Prefixed {
+	p.Errors = append(p.Errors, unpackErrors(errs...)...)
+	return p
+}
+
+// ErrorOrNil either returns nil when the type is nil or when there's no Errors.
+// Otherwise, the type is returned.
+func (p *Prefixed) ErrorOrNil() error {
+	if len(p.Errors) > 0 {
+		return p
+	}
+
+	return nil
+}
+
+func (p *Prefixed) Error() string {
+	if len(p.Errors) == 0 {
+		return ""
+	}
+
+	if p.FormatFunc == nil {
+		p.FormatFunc = multierror.ListFormatFunc
+	}
+
+	return fmt.Sprint(p.Prefix, ": ", p.FormatFunc(p.Errors))
+}
+
+func unpackErrors(errs ...error) []error {
+	var result = make([]error, 0, len(errs))
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+
+		if e, ok := err.(*Prefixed); ok {
+			result = append(result, prefixIndividualErrors(e)...)
+			continue
+		}
+		if e, ok := err.(*multierror.Error); ok {
+			result = append(result, e.Errors...)
+			continue
+		}
+		result = append(result, err)
+	}
+	return result
+}
+
+func prefixIndividualErrors(prefixed *Prefixed) []error {
+	var result = make([]error, 0, len(prefixed.Errors))
+	for _, errElement := range prefixed.Errors {
+		if prefixed.Prefix == "" {
+			// Calling it with skip 3 since there's 3 internal calls which must
+			// be skipped until the external call can surface.
+			if pc, _, _, ok := runtime.Caller(3); ok {
+				if details := runtime.FuncForPC(pc); details != nil {
+					prefixed.Prefix = details.Name()
+				}
+			}
+		}
+		result = append(result, errors.New(
+			fmt.Sprint(prefixed.Prefix, ": ", errElement.Error()),
+		))
+	}
+	return result
+}

--- a/pkg/multierror/prefixed_example_test.go
+++ b/pkg/multierror/prefixed_example_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package multierror
 
 import (

--- a/pkg/multierror/prefixed_example_test.go
+++ b/pkg/multierror/prefixed_example_test.go
@@ -1,0 +1,21 @@
+package multierror
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestExamplePrefixed(t *testing.T) {
+	t.Run("testExample", func(t *testing.T) {
+		var b = new(bytes.Buffer)
+		output = b
+		var want = new(bytes.Buffer)
+		want.WriteString("config validation: 1 error occurred:\n\t* some validation error\n\n\n")
+
+		ExamplePrefixed()
+
+		if b.String() != want.String() {
+			t.Errorf("ExamplePrefixed = %v, want = %v", b.String(), want.String())
+		}
+	})
+}

--- a/pkg/multierror/prefixed_test.go
+++ b/pkg/multierror/prefixed_test.go
@@ -1,0 +1,289 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package multierror
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+func TestNewPrefixed(t *testing.T) {
+	type args struct {
+		prefix string
+		errs   []error
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Prefixed
+	}{
+		{
+			name: "New without explicit prefix",
+			want: &Prefixed{
+				Errors: make([]error, 0),
+			},
+		},
+		{
+			name: "New with prefix and errors",
+			args: args{prefix: "some prefix here", errs: []error{
+				errors.New("an error"),
+				errors.New("another error"),
+				errors.New("yet another error"),
+			}},
+			want: &Prefixed{
+				Prefix: "some prefix here",
+				Errors: []error{
+					errors.New("an error"),
+					errors.New("another error"),
+					errors.New("yet another error"),
+				},
+			},
+		},
+		{
+			name: "New with prefix and errors and unpacking some other prefixed errors",
+			args: args{prefix: "some prefix here", errs: []error{
+				errors.New("an error"),
+				errors.New("another error"),
+				&Prefixed{Prefix: "a prefix", Errors: []error{
+					errors.New("an error"),
+					errors.New("another error"),
+				}},
+			}},
+			want: &Prefixed{
+				Prefix: "some prefix here",
+				Errors: []error{
+					errors.New("an error"),
+					errors.New("another error"),
+					errors.New("a prefix: an error"),
+					errors.New("a prefix: another error"),
+				},
+			},
+		},
+		{
+			name: "New with prefix and errors and unpacking some other prefixed errors and some multierrors",
+			args: args{prefix: "some prefix here", errs: []error{
+				errors.New("an error"),
+				errors.New("another error"),
+				&Prefixed{Prefix: "a prefix", Errors: []error{
+					errors.New("an error"),
+					errors.New("another error"),
+				}},
+				&multierror.Error{Errors: []error{
+					errors.New("multierror error"),
+					errors.New("multierror error 2"),
+				}},
+			}},
+			want: &Prefixed{
+				Prefix: "some prefix here",
+				Errors: []error{
+					errors.New("an error"),
+					errors.New("another error"),
+					errors.New("a prefix: an error"),
+					errors.New("a prefix: another error"),
+					errors.New("multierror error"),
+					errors.New("multierror error 2"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewPrefixed(tt.args.prefix, tt.args.errs...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New() = %+v, want %+v", *got, *tt.want)
+			}
+		})
+	}
+}
+
+func TestPrefixed_Append(t *testing.T) {
+	type fields struct {
+		Prefix     string
+		Errors     []error
+		FormatFunc FormatFunc
+	}
+	type args struct {
+		errs []error
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *Prefixed
+	}{
+		{
+			name: "Adds some errors",
+			fields: fields{Prefix: "some prefix", Errors: []error{
+				errors.New("an error"),
+			}},
+			args: args{errs: []error{
+				&Prefixed{Prefix: "prefix 1", Errors: []error{
+					errors.New("a prefixed error"),
+					errors.New("another error"),
+				}},
+				&Prefixed{Prefix: "prefix 2", Errors: []error{
+					errors.New("a prefixed error"),
+					errors.New("another error"),
+				}},
+				errors.New("a normal error"),
+				// No prefix
+				&Prefixed{Errors: []error{
+					errors.New("a prefixed error"),
+					errors.New("another error"),
+				}},
+			}},
+			want: &Prefixed{
+				Prefix: "some prefix",
+				Errors: []error{
+					errors.New("an error"),
+					errors.New("prefix 1: a prefixed error"),
+					errors.New("prefix 1: another error"),
+					errors.New("prefix 2: a prefixed error"),
+					errors.New("prefix 2: another error"),
+					errors.New("a normal error"),
+					errors.New("github.com/elastic/cloud-sdk-go/pkg/multierror.TestPrefixed_Append.func1: a prefixed error"),
+					errors.New("github.com/elastic/cloud-sdk-go/pkg/multierror.TestPrefixed_Append.func1: another error"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Prefixed{
+				Prefix:     tt.fields.Prefix,
+				Errors:     tt.fields.Errors,
+				FormatFunc: tt.fields.FormatFunc,
+			}
+			if got := p.Append(tt.args.errs...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Prefixed.Append() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrefixed_ErrorOrNil(t *testing.T) {
+	type fields struct {
+		Prefix     string
+		Errors     []error
+		FormatFunc FormatFunc
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		err    error
+	}{
+		{
+			name: "empty error returns nil",
+			err:  nil,
+		},
+		{
+			name: "a Prefixed error with multiple errors returns the error",
+			fields: fields{Errors: []error{
+				errors.New("some error"),
+				errors.New("some other error"),
+			}},
+			err: &Prefixed{Errors: []error{
+				errors.New("some error"),
+				errors.New("some other error"),
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Prefixed{
+				Prefix:     tt.fields.Prefix,
+				Errors:     tt.fields.Errors,
+				FormatFunc: tt.fields.FormatFunc,
+			}
+			if err := p.ErrorOrNil(); !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("Prefixed.ErrorOrNil() error = %+v, wantErr %+v", err, tt.err)
+			}
+		})
+	}
+}
+
+func TestPrefixed_Error(t *testing.T) {
+	type fields struct {
+		Prefix     string
+		Errors     []error
+		FormatFunc FormatFunc
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "empty errors return empty string",
+			want: "",
+		},
+		{
+			name: "Empty FormatFunc uses the default one",
+			fields: fields{
+				Prefix: "prefix",
+				Errors: []error{
+					errors.New("some error"),
+				},
+			},
+			want: "prefix: " + multierror.ListFormatFunc([]error{
+				errors.New("some error"),
+			}),
+		},
+		{
+			name: "Empty FormatFunc uses the default one with more than 1 error",
+			fields: fields{
+				Prefix: "prefix",
+				Errors: []error{
+					errors.New("some error"),
+					errors.New("another error"),
+				},
+			},
+			want: "prefix: " + multierror.ListFormatFunc([]error{
+				errors.New("some error"),
+				errors.New("another error"),
+			}),
+		},
+		{
+			name: "With a custom FormatFunc ",
+			fields: fields{
+				Prefix: "prefix",
+				FormatFunc: func(es []error) string {
+					return "some bogus return"
+				},
+				Errors: []error{
+					errors.New("some error"),
+				},
+			},
+			want: "prefix: some bogus return",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Prefixed{
+				Prefix:     tt.fields.Prefix,
+				Errors:     tt.fields.Errors,
+				FormatFunc: tt.fields.FormatFunc,
+			}
+			if got := p.Error(); got != tt.want {
+				t.Errorf("Prefixed.Error() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new package under `pkg/multierror` which is aimed to be used
instead of `multierror.Error`. The main motivation behind this change is
to enforce a prefix to be used in all of the multierrors which will
provide more context to the error consumers.

It features multierror unpacking to keep all the errors same level and
in case the wrapped errors are also a Prefixed type, a prefix will be
added to each of the single errors to add that additional context to it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Have more context in our errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests, as an example: 


```go
// code:
func (c *Config) Validate() error {
	var err = multierror.NewPrefixed("api config validation")
	if c.Client == nil {
		err = err.Append(errors.New("client cannot be empty"))
	}

	if c.AuthWriter == nil {
		err = err.Append(errEmptyAuthWriter)
	}

	err = err.Append(checkHost(c.Host))
	err = err.Append(c.VerboseSettings.Validate())

	return err.ErrorOrNil()
}

func (settings VerboseSettings) Validate() error {
	var err = multierror.NewPrefixed("api verbose config validation")
	if settings.Verbose && settings.Device == nil {
		err = err.Append(errors.New(
			"invalid verbose settings: output device cannot be empty when verbose is enabled",
		))
	}

	return err.ErrorOrNil()
}


// Output: 
      api config validation: 3 errors occurred:
            	* AuthWriter must not be empty
            	* host cannot be empty
            	* api verbose config validation: invalid verbose settings: output device cannot be empty when verbose is enabled
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

