### PR TITLE
cmdutil: Add DecodeFlags to reduce parsing code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,11 @@ require (
 	github.com/go-openapi/swag v0.19.8
 	github.com/go-openapi/validate v0.19.7
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/cobra v0.0.7
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 )
 
 replace sourcegraph.com/sourcegraph/go-diff v0.5.1 => github.com/sourcegraph/go-diff v0.5.1

--- a/pkg/util/cmdutil/flag.go
+++ b/pkg/util/cmdutil/flag.go
@@ -75,7 +75,7 @@ func parseValue(val pflag.Value) interface{} {
 }
 
 func parseDurationSlice(i interface{}) []time.Duration {
-	var durationSlice []time.Duration
+	var durationSlice = make([]time.Duration, 0)
 	for _, d := range i.([]string) {
 		dVal, _ := time.ParseDuration(d)
 		durationSlice = append(durationSlice, dVal)
@@ -84,7 +84,7 @@ func parseDurationSlice(i interface{}) []time.Duration {
 }
 
 func parseIPSlice(i interface{}) []net.IP {
-	var ipSlice []net.IP
+	var ipSlice = make([]net.IP, 0)
 	for _, ip := range i.([]string) {
 		ipSlice = append(ipSlice, net.ParseIP(ip))
 	}

--- a/pkg/util/cmdutil/flag_test.go
+++ b/pkg/util/cmdutil/flag_test.go
@@ -85,6 +85,7 @@ func TestDecodeFlags(t *testing.T) {
 	type nested struct {
 		Prop string `mapstructure:"some-prop"`
 	}
+	// nolint
 	type cfg struct {
 		// Standard types
 		SomeString   string        `mapstructure:"some-string"`

--- a/pkg/util/cmdutil/flag_test.go
+++ b/pkg/util/cmdutil/flag_test.go
@@ -19,8 +19,10 @@ package cmdutil
 
 import (
 	"errors"
+	"net"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -74,6 +76,154 @@ func TestIncompatibleFlags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := IncompatibleFlags(tt.args.cmd, tt.args.first, tt.args.second); !reflect.DeepEqual(err, tt.err) {
 				t.Errorf("IncompatibleFlags() error = %v, wantErr %v", err, tt.err)
+			}
+		})
+	}
+}
+
+func TestDecodeFlags(t *testing.T) {
+	type nested struct {
+		Prop string `mapstructure:"some-prop"`
+	}
+	type cfg struct {
+		// Standard types
+		SomeString   string        `mapstructure:"some-string"`
+		SomeBool     bool          `mapstructure:"some-bool"`
+		SomeInt      int           `mapstructure:"some-int"`
+		SomeInt32    int32         `mapstructure:"some-int32"`
+		SomeInt64    int64         `mapstructure:"some-int64"`
+		SomeUint     uint          `mapstructure:"some-uint"`
+		SomeUint32   uint32        `mapstructure:"some-uint32"`
+		SomeUint64   uint64        `mapstructure:"some-uint64"`
+		SomeFloat32  float32       `mapstructure:"some-float32"`
+		SomeFloat64  float64       `mapstructure:"some-float64"`
+		SomeDuration time.Duration `mapstructure:"some-duration"`
+		SomeIP       net.IP        `mapstructure:"some-ip"`
+		SomeIPMask   net.IPMask    `mapstructure:"some-ip-mask"`
+		SomeIPNet    net.IPNet     `mapstructure:"some-ip-net"`
+
+		nested `mapstructure:",squash"`
+
+		// Slices
+		SomeStringSlice   []string        `mapstructure:"some-string-slice"`
+		SomeStringArray   []string        `mapstructure:"some-string-array"`
+		SomeBoolSlice     []bool          `mapstructure:"some-bool-slice"`
+		SomeIntSlice      []int           `mapstructure:"some-int-slice"`
+		SomeUintSlice     []uint          `mapstructure:"some-uint-slice"`
+		SomeInt32Slice    []int32         `mapstructure:"some-int32-slice"`
+		SomeInt64Slice    []int64         `mapstructure:"some-int64-slice"`
+		SomeFloat32Slice  []float32       `mapstructure:"some-float32-slice"`
+		SomeFloat64Slice  []float64       `mapstructure:"some-float64-slice"`
+		SomeDurationSlice []time.Duration `mapstructure:"some-duration-slice"`
+		SomeIPSlice       []net.IP        `mapstructure:"some-ip-slice"`
+	}
+
+	cobraCommand := &cobra.Command{}
+
+	// Generic types
+	cobraCommand.Flags().String("some-string", "defaultVal", "some desc")
+	cobraCommand.Flag("some-string").Value.Set("my value")
+
+	cobraCommand.Flags().String("some-prop", "nestedPropVal", "some desc")
+
+	cobraCommand.Flags().Bool("some-bool", false, "some desc")
+	cobraCommand.Flag("some-bool").Value.Set("true")
+
+	cobraCommand.Flags().Int("some-int", 100, "some desc")
+	cobraCommand.Flags().Int32("some-int32", 2000, "some desc")
+	cobraCommand.Flags().Int64("some-int64", 20000, "some desc")
+
+	cobraCommand.Flags().Uint("some-uint", 100, "some desc")
+	cobraCommand.Flags().Uint32("some-uint32", 2000, "some desc")
+	cobraCommand.Flags().Uint64("some-uint64", 20000, "some desc")
+
+	cobraCommand.Flags().Float32("some-float32", 100.1, "some desc")
+	cobraCommand.Flags().Float64("some-float64", 100.2, "some desc")
+
+	cobraCommand.Flags().Duration("some-duration", time.Second, "some desc")
+
+	ip, ipNet, err := net.ParseCIDR("192.168.1.1/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cobraCommand.Flags().IP("some-ip", ip, "some desc")
+	cobraCommand.Flags().IPMask("some-ip-mask", ipNet.Mask, "some desc")
+	cobraCommand.Flags().IPNet("some-ip-net", *ipNet, "some desc")
+
+	// Slice types
+
+	cobraCommand.Flags().StringSlice("some-string-slice", []string{"someval"}, "some desc")
+	cobraCommand.Flags().StringArray("some-string-array", []string{"someval-array"}, "some desc")
+
+	cobraCommand.Flags().BoolSlice("some-bool-slice", []bool{false, true}, "some desc")
+
+	cobraCommand.Flags().IntSlice("some-int-slice", []int{100, 200}, "some desc")
+	cobraCommand.Flags().Int32Slice("some-int32-slice", []int32{100, 200}, "some desc")
+	cobraCommand.Flags().Int64Slice("some-int64-slice", []int64{100, 200}, "some desc")
+
+	cobraCommand.Flags().UintSlice("some-uint-slice", []uint{100, 200}, "some desc")
+
+	cobraCommand.Flags().Float32Slice("some-float32-slice", []float32{100.1, 100.2}, "some desc")
+	cobraCommand.Flags().Float64Slice("some-float64-slice", []float64{100.1, 100.2, 100.3}, "some desc")
+
+	cobraCommand.Flags().DurationSlice("some-duration-slice", []time.Duration{time.Second, time.Hour}, "some desc")
+
+	ipSlice := []net.IP{net.ParseIP("192.168.1.1"), net.ParseIP("192.168.1.2")}
+	cobraCommand.Flags().IPSlice("some-ip-slice", ipSlice, "some desc")
+
+	type args struct {
+		cmd *cobra.Command
+		dst interface{}
+	}
+	tests := []struct {
+		name       string
+		args       args
+		err        error
+		wantStruct interface{}
+	}{
+		{
+			name: "Parses all available types",
+			args: args{cmd: cobraCommand, dst: &cfg{}},
+			wantStruct: &cfg{
+				nested: nested{
+					Prop: "nestedPropVal",
+				},
+				SomeString:        "my value",
+				SomeBool:          true,
+				SomeInt:           100,
+				SomeInt32:         2000,
+				SomeInt64:         20000,
+				SomeUint:          100,
+				SomeUint32:        2000,
+				SomeUint64:        20000,
+				SomeFloat32:       100.1,
+				SomeFloat64:       100.2,
+				SomeDuration:      time.Second,
+				SomeIP:            ip,
+				SomeIPMask:        ipNet.Mask,
+				SomeIPNet:         *ipNet,
+				SomeIntSlice:      []int{100, 200},
+				SomeInt32Slice:    []int32{100, 200},
+				SomeInt64Slice:    []int64{100, 200},
+				SomeUintSlice:     []uint{100, 200},
+				SomeFloat32Slice:  []float32{100.1, 100.2},
+				SomeFloat64Slice:  []float64{100.1, 100.2, 100.3},
+				SomeDurationSlice: []time.Duration{time.Second, time.Hour},
+				SomeBoolSlice:     []bool{false, true},
+				SomeStringSlice:   []string{"someval"},
+				SomeStringArray:   []string{"someval-array"},
+				SomeIPSlice:       ipSlice,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := DecodeFlags(tt.args.cmd, tt.args.dst); !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("DecodeFlags() error = %v, wantErr %v", err, tt.err)
+			}
+
+			if !reflect.DeepEqual(tt.args.dst, tt.wantStruct) {
+				t.Errorf("DecodeFlags() values = \n%+v, wantStruct \n%+v", tt.args.dst, tt.wantStruct)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new `DecodeFlags` function which through reflection and
`mapstructure` is able to decode a cobra.Command defined flags into a
structure's fields which match the flag's type and mapstructure tag.

By using this function we can greatly reduce the flag-parsing code and
offload most if not all of the flag parsing by using this function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Projects which use the cobra framework to parse flags and populate a
structure can use this function and reduce all of boilerplate code which
doesn't add any value.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By using it in ecctl. An example on how much code can be deleted:

```diff
diff --git a/cmd/deployment/show.go b/cmd/deployment/show.go
index f3ad90d..56f2f93 100644
--- a/cmd/deployment/show.go
+++ b/cmd/deployment/show.go
@@ -25,7 +25,6 @@ import (
 
 	cmdutil "github.com/elastic/ecctl/cmd/util"
 	"github.com/elastic/ecctl/pkg/deployment"
-	"github.com/elastic/ecctl/pkg/deployment/deputil"
 	"github.com/elastic/ecctl/pkg/ecctl"
 )
 
@@ -49,34 +48,16 @@ var showCmd = &cobra.Command{
 			return errors.Errorf(`"%v" is not a valid resource kind. Accepted resource kinds are: %v`, resourceKind, acceptedKinds)
 		}
 
-		planLogs, _ := cmd.Flags().GetBool("plan-logs")
-		planDefaults, _ := cmd.Flags().GetBool("plan-defaults")
-		planHistory, _ := cmd.Flags().GetBool("plan-history")
-		metadata, _ := cmd.Flags().GetBool("metadata")
-		settings, _ := cmd.Flags().GetBool("settings")
-		plans, _ := cmd.Flags().GetBool("plans")
-		showPlans := planLogs || planDefaults || plans || planHistory
-
-		refID, _ := cmd.Flags().GetString("ref-id")
-		getParams := deployment.GetParams{
+		params := deployment.GetResourceParams{GetParams: deployment.GetParams{
 			API:          ecctl.Get().API,
 			DeploymentID: args[0],
-			RefID:        refID,
-			QueryParams: deputil.QueryParams{
-				ShowPlans:        showPlans,
-				ShowPlanLogs:     planLogs,
-				ShowPlanDefaults: planDefaults,
-				ShowPlanHistory:  planHistory,
-				ShowMetadata:     metadata,
-				ShowSettings:     settings,
-			},
-		}
+		}}
 
-		res, err := deployment.GetResource(deployment.GetResourceParams{
-			GetParams: getParams,
-			Kind:      resourceKind,
-		})
+		if err := sdkcmdutil.DecodeFlags(cmd, &params); err != nil {
+			return err
+		}
 
+		res, err := deployment.GetResource(params)
 		if err != nil {
 			return err
 		}
diff --git a/pkg/deployment/get.go b/pkg/deployment/get.go
index 7ef42e0..64bf5ba 100644
--- a/pkg/deployment/get.go
+++ b/pkg/deployment/get.go
@@ -36,15 +36,16 @@ type GetParams struct {
 	DeploymentID string
 
 	// Optional parameters
-	deputil.QueryParams
+	deputil.QueryParams `mapstructure:",squash"`
 
 	// RefID, when specified, skips auto-discovering the deployment resource
 	// RefID and instead uses the one that's passed.
-	RefID string
+	RefID string `mapstructure:"ref-id"`
 }
 
 // Validate ensures that the parameters are usable by the consuming function.
-func (params GetParams) Validate() error {
+func (params *GetParams) Validate() error {
+	defer params.fillDefaults()
 	var merr = new(multierror.Error)
 	if params.API == nil {
 		merr = multierror.Append(merr, util.ErrAPIReq)
@@ -57,6 +58,10 @@ func (params GetParams) Validate() error {
 	return merr.ErrorOrNil()
 }
 
+func (params *GetParams) fillDefaults() {
+	params.ShowPlans = params.ShowPlanLogs || params.ShowPlanDefaults || params.ShowPlans || params.ShowPlanHistory
+}
+
 // Get returns info about a deployment.
 func Get(params GetParams) (*models.DeploymentGetResponse, error) {
 	if err := params.Validate(); err != nil {

```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

