### PR TITLE
api: Move LoginUser from ecctl codebase

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v1.2.2 h1:dxe5oCinTXiTIcfgmZecdCzPmAJKd46KsCWc35r0TV4=
-github.com/mitchellh/mapstructure v1.2.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.2.3 h1:f/MjBEBDLttYCGfRaKBbKSRVF5aV2O6fnBpzknuE3jU=
 github.com/mitchellh/mapstructure v1.2.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -24,10 +24,9 @@ import (
 	"reflect"
 	"testing"
 
-	multierror "github.com/hashicorp/go-multierror"
-
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/auth"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/elastic/cloud-sdk-go/pkg/output"
 )
 
@@ -42,11 +41,11 @@ func TestNewAPI(t *testing.T) {
 	}{
 		{
 			name: "fails due to empty parameters",
-			err: &multierror.Error{Errors: []error{
-				errors.New("api: client cannot be empty"),
+			err: multierror.NewPrefixed("invalid api config",
+				errors.New("client cannot be empty"),
 				errEmptyAuthWriter,
-				errors.New("api: host cannot be empty"),
-			}},
+				errors.New("host cannot be empty"),
+			),
 		},
 		{
 			name: "fails with invalid url",
@@ -58,10 +57,10 @@ func TestNewAPI(t *testing.T) {
 				},
 				Client: mock.NewClient(),
 			}},
-			err: &multierror.Error{Errors: []error{
+			err: multierror.NewPrefixed("invalid api config",
 				errEmptyAuthWriter,
 				&url.Error{Op: "parse", URL: "very.much.invalid/", Err: errors.New("invalid URI for request")},
-			}},
+			),
 		},
 		{
 			name: "succeeds with region",

--- a/pkg/api/apierror/unwrap.go
+++ b/pkg/api/apierror/unwrap.go
@@ -1,0 +1,92 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apierror
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"unsafe"
+
+	"github.com/go-openapi/runtime"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// Unwrap unpacks an error message returned from a client API call.
+func Unwrap(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if reflect.Ptr != reflect.ValueOf(err).Kind() {
+		if err == context.DeadlineExceeded {
+			return errors.New("operation timed out")
+		}
+		return err
+	}
+	if e, ok := err.(*runtime.APIError); ok {
+		if e.Code == 449 {
+			return errors.New("the requested operation requires elevated permissions")
+		}
+
+		var defaultError = fmt.Errorf("%s (status %d)", e.OperationName, e.Code)
+		if e.Response != nil {
+			if v := reflect.ValueOf(e.Response); v.IsValid() {
+				if resp := v.FieldByName("resp"); resp.IsValid() {
+					ptr := unsafe.Pointer(resp.Pointer())
+					res := (*http.Response)(ptr)
+					b, err := ioutil.ReadAll(res.Body)
+					if err != nil {
+						return fmt.Errorf(
+							"failed reading error body: %s", defaultError,
+						)
+					}
+					defer res.Body.Close()
+					return errors.New(string(b))
+				}
+			}
+		}
+
+		if res, _ := json.MarshalIndent(e.Response, "", "  "); !bytes.Equal(res, []byte("{}")) {
+			return errors.New(string(res))
+		}
+		return defaultError
+	}
+
+	payload := reflect.ValueOf(err).Elem().FieldByName("Payload")
+	if payload.IsValid() {
+		if r, ok := payload.Interface().(*models.BasicFailedReply); ok {
+			merr := multierror.NewPrefixed("api error")
+			for _, e := range r.Errors {
+				merr = merr.Append(fmt.Errorf("%s: %s", *e.Code, *e.Message))
+			}
+			return merr.ErrorOrNil()
+		}
+		res, _ := json.MarshalIndent(payload.Interface(), "", "  ")
+		return errors.New(string(res))
+	}
+
+	return err
+}

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -23,9 +23,8 @@ import (
 	"reflect"
 	"testing"
 
-	multierror "github.com/hashicorp/go-multierror"
-
 	"github.com/elastic/cloud-sdk-go/pkg/auth"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -45,21 +44,21 @@ func TestConfig_Validate(t *testing.T) {
 		{
 			name:   "Validate fails due on empty config",
 			fields: Config{},
-			err: &multierror.Error{Errors: []error{
-				errors.New("api: client cannot be empty"),
+			err: multierror.NewPrefixed("invalid api config",
+				errors.New("client cannot be empty"),
 				errEmptyAuthWriter,
-				errors.New("api: host cannot be empty"),
-			}},
+				errors.New("host cannot be empty"),
+			),
 		},
 		{
 			name: "Validate fails due to missing Authenticator",
 			fields: Config{
 				Client: new(http.Client),
 			},
-			err: &multierror.Error{Errors: []error{
+			err: multierror.NewPrefixed("invalid api config",
 				errEmptyAuthWriter,
-				errors.New("api: host cannot be empty"),
-			}},
+				errors.New("host cannot be empty"),
+			),
 		},
 		{
 			name: "Validate fails due to verbose set but device empty",
@@ -67,11 +66,13 @@ func TestConfig_Validate(t *testing.T) {
 				Client:          new(http.Client),
 				VerboseSettings: VerboseSettings{Verbose: true},
 			},
-			err: &multierror.Error{Errors: []error{
+			err: multierror.NewPrefixed("invalid api config",
 				errEmptyAuthWriter,
-				errors.New("api: host cannot be empty"),
-				errors.New("api: invalid verbose settings: output device cannot be empty when verbose is enabled"),
-			}},
+				errors.New("host cannot be empty"),
+				multierror.NewPrefixed("invalid verbose settings",
+					errors.New("output device cannot be empty when verbose is enabled"),
+				),
+			),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/api/login_user.go
+++ b/pkg/api/login_user.go
@@ -17,11 +17,27 @@
 
 package api
 
-import "github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+import (
+	"io"
 
-// UnwrapError (DEPRECATED) unpacks an error message returned from a client API
-// call.
-// THIS METHOD IS DEPRECATED IN FAVOUR OF apierror.Unwrap().
-func UnwrapError(err error) error {
-	return apierror.Unwrap(err)
+	"github.com/elastic/cloud-sdk-go/pkg/auth"
+)
+
+// LoginUser logs in a user when its AuthWriter is of type *auth.UserLogin.
+// Additionally, calls the RefreshToken pethod in *auth.UserLogin launching a
+// background Go routine which will keep the JWT token always valid.
+func LoginUser(instance *API, writer io.Writer) error {
+	aw, ok := instance.AuthWriter.(*auth.UserLogin)
+	if !ok {
+		return nil
+	}
+
+	if err := aw.Login(instance.V1API); err != nil {
+		return err
+	}
+
+	return aw.RefreshToken(auth.RefreshTokenParams{
+		Client:      instance.V1API,
+		ErrorDevice: writer,
+	})
 }

--- a/pkg/api/login_user_test.go
+++ b/pkg/api/login_user_test.go
@@ -1,0 +1,85 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/auth"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestLoginUser(t *testing.T) {
+	var apiKeyAPI = NewMock()
+	var userLoginError = NewMock(mock.New500Response(mock.NewStringBody("error")))
+	fail, err := auth.NewUserLogin("user", "pass")
+	if err != nil {
+		t.Fatal(err)
+	}
+	userLoginError.AuthWriter = fail
+
+	var userLoginSuccess = NewMock(mock.New200Response(mock.NewStructBody(models.TokenResponse{
+		Token: ec.String("sometoken"),
+	})))
+	success, err := auth.NewUserLogin("user", "pass")
+	if err != nil {
+		t.Fatal(err)
+	}
+	userLoginSuccess.AuthWriter = success
+	type args struct {
+		instance *API
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantWriter string
+		err        error
+	}{
+		{
+			name: "skips logging in when the AuthWriter isn't *auth.UserLogin",
+			args: args{instance: apiKeyAPI},
+		},
+		{
+			name: "fails logging in",
+			args: args{instance: userLoginError},
+			err:  multierror.NewPrefixed("failed to login with user/password", errors.New("error")),
+		},
+		{
+			name: "succeeds logging in",
+			args: args{instance: userLoginSuccess},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := &bytes.Buffer{}
+			if err := LoginUser(tt.args.instance, writer); !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("LoginUser() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if gotWriter := writer.String(); gotWriter != tt.wantWriter {
+				t.Errorf("LoginUser() = %v, want %v", gotWriter, tt.wantWriter)
+			}
+		})
+	}
+}

--- a/pkg/api/mock/error.go
+++ b/pkg/api/mock/error.go
@@ -1,0 +1,54 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mock
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+)
+
+// APIError can be used to create a multiple error response.
+type APIError struct {
+	Code, Message string
+	Fields        []string
+}
+
+// NewErrorBody creates a replica of a body representing an EC API error.
+func NewErrorBody(errs ...APIError) io.ReadCloser {
+	var replies = make([]*models.BasicFailedReplyElement, 0, len(errs))
+	for _, e := range errs {
+		replies = append(replies, &models.BasicFailedReplyElement{
+			Code: &e.Code, Message: &e.Message, Fields: e.Fields,
+		})
+	}
+	return NewStructBody(models.BasicFailedReply{
+		Errors: replies,
+	})
+}
+
+// NewErrorResponse creates a replica of a responnse representing an EC API
+// error.
+func NewErrorResponse(code int, errs ...APIError) Response {
+	return Response{Response: http.Response{
+		StatusCode: code,
+		Status:     http.StatusText(code),
+		Body:       NewErrorBody(errs...),
+	}}
+}

--- a/pkg/api/mock/error_test.go
+++ b/pkg/api/mock/error_test.go
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mock
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestNewErrorResponse(t *testing.T) {
+	type args struct {
+		code int
+		errs []APIError
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Creates a 400 error response",
+			args: args{code: 400, errs: []APIError{
+				{Code: "some code", Message: "Some message", Fields: []string{"f1", "f2"}},
+			}},
+			want: Response{Response: http.Response{
+				StatusCode: 400,
+				Status:     http.StatusText(400),
+				Body: NewStructBody(models.BasicFailedReply{
+					Errors: []*models.BasicFailedReplyElement{
+						{
+							Code:    ec.String("some code"),
+							Message: ec.String("Some message"),
+							Fields:  []string{"f1", "f2"},
+						},
+					},
+				}),
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewErrorResponse(tt.args.code, tt.args.errs...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewErrorResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/api/mock/errors.go
+++ b/pkg/api/mock/errors.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mock
+
+import (
+	"fmt"
+
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+const (
+	code500    = "internal.server.error"
+	message500 = "There was an internal server error"
+)
+
+const (
+	code404    = "deployments.deployment_not_found"
+	message404 = "No Deployment with id [62bed072dffd4509b84dfe7dc125bb12] could be found"
+)
+
+const (
+	code400    = "root.invalid_json_request"
+	message400 = "JSON request does not comply with schema: [String: DownField(region),DownArray,DownField(elasticsearch),DownField(resources): [String]]"
+)
+
+var (
+	// MultierrorInternalError represents the multierror returned by apier.Unwrap().
+	MultierrorInternalError = multierror.NewPrefixed("api error",
+		fmt.Errorf("%s: %s", code500, message500),
+	)
+
+	// MultierrorNotFound represents the multierror returned by apier.Unwrap().
+	MultierrorNotFound = multierror.NewPrefixed("api error",
+		fmt.Errorf("%s: %s", code404, message404),
+	)
+
+	// MultierrorBadRequest represents the multierror returned by apier.Unwrap().
+	MultierrorBadRequest = multierror.NewPrefixed("api error",
+		fmt.Errorf("%s: %s", code400, message400),
+	)
+)
+
+// SampleInternalError returns a response which encapsulates a 500 error.
+func SampleInternalError() Response {
+	return NewErrorResponse(500, APIError{Code: code500, Message: message500})
+}
+
+// SampleNotFoundError returns a response which encapsulates a 404 error.
+func SampleNotFoundError() Response {
+	return NewErrorResponse(404, APIError{Code: code404, Message: message404})
+}
+
+// SampleBadRequestError returns a response which encapsulates a 400 error.
+func SampleBadRequestError() Response {
+	return NewErrorResponse(400, APIError{Code: code400, Message: message400})
+}

--- a/pkg/api/mock/errors_test.go
+++ b/pkg/api/mock/errors_test.go
@@ -1,0 +1,108 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mock
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestSampleInternalError(t *testing.T) {
+	tests := []struct {
+		name string
+		want Response
+	}{
+		{
+			name: "obtains the response",
+			want: Response{Response: http.Response{
+				StatusCode: 500,
+				Status:     http.StatusText(500),
+				Body: NewStructBody(models.BasicFailedReply{
+					Errors: []*models.BasicFailedReplyElement{
+						{Code: ec.String(code500), Message: ec.String(message500)},
+					},
+				}),
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SampleInternalError(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SampleInternalError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSampleNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		want Response
+	}{
+		{
+			name: "obtains the response",
+			want: Response{Response: http.Response{
+				StatusCode: 404,
+				Status:     http.StatusText(404),
+				Body: NewStructBody(models.BasicFailedReply{
+					Errors: []*models.BasicFailedReplyElement{
+						{Code: ec.String(code404), Message: ec.String(message404)},
+					},
+				}),
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SampleNotFoundError(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SampleNotFoundError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSampleBadRequestError(t *testing.T) {
+	tests := []struct {
+		name string
+		want Response
+	}{
+		{
+			name: "obtains the response",
+			want: Response{Response: http.Response{
+				StatusCode: 400,
+				Status:     http.StatusText(400),
+				Body: NewStructBody(models.BasicFailedReply{
+					Errors: []*models.BasicFailedReplyElement{
+						{Code: ec.String(code400), Message: ec.String(message400)},
+					},
+				}),
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SampleBadRequestError(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SampleBadRequestError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/auth/new_authwriter.go
+++ b/pkg/auth/new_authwriter.go
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package auth
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-openapi/runtime"
+
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// Writer wraps the runtime.ClientAuthInfoWriter interface adding a method
+// to Auth generic http.Request.
+type Writer interface {
+	runtime.ClientAuthInfoWriter
+	AuthRequest(req *http.Request) *http.Request
+}
+
+// Config to create e new AuthWriters
+type Config struct {
+	APIKey   string
+	Password string
+	Username string
+}
+
+// Validate ensures that the config is usable.
+func (c Config) Validate() error {
+	var merr = multierror.NewPrefixed("authwriter")
+	var emptyAPIKey = c.APIKey == ""
+	var emptyUser = c.Username == ""
+	var emptyPass = c.Password == ""
+
+	var emptyCreds = emptyAPIKey && emptyUser && emptyPass
+	if emptyCreds {
+		merr = merr.Append(
+			errors.New("one of apikey or username and password must be specified"),
+		)
+	}
+
+	var allCreds = !emptyAPIKey && (!emptyUser || !emptyPass)
+	if allCreds {
+		merr = merr.Append(
+			errors.New("only one of of apikey or username and password can be specified"),
+		)
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// NewAuthWriter creates a new instance of one of the implementations of Writer
+// *APIKey or *UserLogin.
+func NewAuthWriter(c Config) (Writer, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+
+	if c.APIKey != "" {
+		return NewAPIKey(c.APIKey)
+	}
+
+	return NewUserLogin(c.Username, c.Password)
+}

--- a/pkg/auth/new_authwriter_test.go
+++ b/pkg/auth/new_authwriter_test.go
@@ -1,0 +1,101 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package auth
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+func TestNewAuthWriter(t *testing.T) {
+	var apikey = APIKey("someapikey")
+
+	type args struct {
+		c Config
+	}
+	tests := []struct {
+		name string
+		args args
+		want Writer
+		err  error
+	}{
+		{
+			name: "when APIKey is set returns an apikey AuthWriter",
+			args: args{c: Config{
+				APIKey: "someapikey",
+			}},
+			want: &apikey,
+		},
+		{
+			name: "when Username and Password is set returns an UserLogin",
+			args: args{c: Config{
+				Username: "myuser", Password: "my very secret password",
+			}},
+			want: &UserLogin{
+				Username: "myuser", Password: "my very secret password",
+				Holder: new(GenericHolder),
+			},
+		},
+		{
+			name: "when Username is set but password is empty returns an error",
+			args: args{c: Config{
+				Username: "myuser",
+			}},
+			err: multierror.NewPrefixed("auth", errors.New("password must not be empty")),
+		},
+		{
+			name: "when Password is set but username is empty returns an error",
+			args: args{c: Config{
+				Password: "my very secret password",
+			}},
+			err: multierror.NewPrefixed("auth", errors.New("username must not be empty")),
+		},
+		{
+			name: "when the credentials are empty returns an error",
+			args: args{c: Config{}},
+			err: multierror.NewPrefixed("authwriter",
+				errors.New("one of apikey or username and password must be specified"),
+			),
+		},
+		{
+			name: "when all the credentials are set returns an error",
+			args: args{c: Config{APIKey: "a", Username: "b", Password: "c"}},
+			err: multierror.NewPrefixed("authwriter",
+				errors.New("only one of of apikey or username and password can be specified"),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewAuthWriter(tt.args.c)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("NewAuthWriter() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if err != nil {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewAuthWriter() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/multierror/prefixed_test.go
+++ b/pkg/multierror/prefixed_test.go
@@ -90,6 +90,10 @@ func TestNewPrefixed(t *testing.T) {
 					errors.New("multierror error"),
 					errors.New("multierror error 2"),
 				}},
+				&Prefixed{Prefix: "some prefix here", Errors: []error{
+					errors.New("unprefixed error 1"),
+					errors.New("unprefixed error 2"),
+				}},
 			}},
 			want: &Prefixed{
 				Prefix: "some prefix here",
@@ -100,6 +104,8 @@ func TestNewPrefixed(t *testing.T) {
 					errors.New("a prefix: another error"),
 					errors.New("multierror error"),
 					errors.New("multierror error 2"),
+					errors.New("unprefixed error 1"),
+					errors.New("unprefixed error 2"),
 				},
 			},
 		},


### PR DESCRIPTION
## Description
This patch contains a few changes aimed to making the SDK friendlier for
consumers, moving logic from external calls to implicit calls on the
API constructing function, controling the behavior through a bool flag
which still allows control over it when desired.

There's multierror changes which have been done to move over from the
multierror package owned from Hashicorp to our own. This wasn't entirely
needed for this patch but it makes the errors and wrapping of errors
that much nicer that it adds good value.

Also Moves the `UnwrapError` function from the `api` package to an
`apierror` subpackage and renaming the function to `Unwrap` this is due
to an import cyclic issue where `api` imports the `auth` package and in
order to be able to unwrap the errors returned in the `auth` package
`auth` would be importing `api` only so it can call `api.UnwrapError`.

Refactors the apierror.Unwrap to several private functions to split the
concerns and make the code more readable. After this patch, the function
will unpack any errors which are of type `*models.BasicFailedReply` to
be wrapped by a `multierror.Prefixed` rather than printing the Marshaled
JSON.

Adds a conditional to the `multierror.Prefixed` which ensures that the
appended error is `*multierror.Prefixed` and the Prefix matches both the
parent and the error which is being added, then the prefix is removed on
appending the error.

Now the `mock` package contains both sample `mock.Response` errors for
consumers to use conveniently as well as what the expected `error` type
for the added functions for testing purposes.

Furthermore, now `auth` does unwrap the errors resulting in less cryptic
errors returned when the user cannot be logged in or the user's bearer
token cannot be refreshed.

Last, adds a `NewAuthWriter` function in the `auth` package so that an
`auth.Writer` can created by either using a populated `Username` and
`Password` or an `APIKey`. This also reduces the need to do that in all
of the multiple clients which need to instantiate an `auth.Writer` to
pass it to the `API` structure.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Less code in the clients, more in the SDKs.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
