### PR TITLE
plan: Use local multierror.Prefixed as multierror

### DIFF
--- a/pkg/plan/planutil/track_test.go
+++ b/pkg/plan/planutil/track_test.go
@@ -25,11 +25,10 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/elastic/cloud-sdk-go/pkg/plan"
 	planmock "github.com/elastic/cloud-sdk-go/pkg/plan/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
@@ -117,21 +116,21 @@ func TestTrackChange(t *testing.T) {
 		{
 			name: "returns error on parameter validation failure (downstream)",
 			args: args{params: TrackChangeParams{}},
-			err: &multierror.Error{Errors: []error{
-				errors.New("plan track change: API cannot be nil"),
-				errors.New("plan track change: one of DeploymentID or ResourceID must be specified"),
-				errors.New("plan track change: Kind cannot be empty"),
-			}},
+			err: multierror.NewPrefixed("plan track change",
+				errors.New("API cannot be nil"),
+				errors.New("one of DeploymentID or ResourceID must be specified"),
+				errors.New("kind cannot be empty"),
+			),
 		},
 		{
 			name: "returns error on parameter validation failure",
 			args: args{params: TrackChangeParams{
 				Format: "some",
 			}},
-			err: &multierror.Error{Errors: []error{
-				errors.New("planutil track change: writer needs to be specified when format is not empty"),
-				errors.New(`planutil track change: invalid format "some"`),
-			}},
+			err: multierror.NewPrefixed("plan track change",
+				errors.New("writer needs to be specified when format is not empty"),
+				errors.New(`invalid format "some"`),
+			),
 		},
 		{
 			name: "tracks a cluster with text format and error result",

--- a/pkg/plan/stream.go
+++ b/pkg/plan/stream.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/hashicorp/go-multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 )
 
 // Stream prints a text formatted line on each TrackResponse received by the
@@ -86,22 +86,22 @@ func StreamJSON(channel <-chan TrackResponse, device io.Writer, pretty bool) err
 // this function will block execution forever. If the plan failed, it returns
 // the error that made the plan fail.
 func StreamFunc(channel <-chan TrackResponse, function func(TrackResponse)) error {
-	var err = new(multierror.Error)
+	var merr = multierror.NewPrefixed("found")
 	for res := range channel {
 		function(res)
 		if res.Err != nil && res.Finished && res.Err != ErrPlanFinished {
-			err = multierror.Append(err, res.Error())
+			merr = merr.Append(res.Error())
 		}
 	}
 
-	return compatibleError(err)
+	return compatibleError(merr)
 }
 
 // compatibleError is a small utility to ensure that the otuput of StreamFunc
 // remains the same as long as the TrackResponse is kept the same.
-func compatibleError(e *multierror.Error) error {
+func compatibleError(e *multierror.Prefixed) error {
 	if e != nil {
-		if e.Len() == 1 {
+		if len(e.Errors) == 1 {
 			return e.Errors[0]
 		}
 	}

--- a/pkg/plan/stream.go
+++ b/pkg/plan/stream.go
@@ -86,7 +86,7 @@ func StreamJSON(channel <-chan TrackResponse, device io.Writer, pretty bool) err
 // this function will block execution forever. If the plan failed, it returns
 // the error that made the plan fail.
 func StreamFunc(channel <-chan TrackResponse, function func(TrackResponse)) error {
-	var merr = multierror.NewPrefixed("found")
+	var merr = multierror.NewPrefixed("found deployment plan errors")
 	for res := range channel {
 		function(res)
 		if res.Err != nil && res.Finished && res.Err != ErrPlanFinished {

--- a/pkg/plan/track_change_params.go
+++ b/pkg/plan/track_change_params.go
@@ -21,9 +21,8 @@ import (
 	"errors"
 	"time"
 
-	multierror "github.com/hashicorp/go-multierror"
-
 	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 )
 
 // TrackChangeParams is consumed by TrackChange. It can be used to track
@@ -66,47 +65,47 @@ type TrackFrequencyConfig struct {
 
 // Validate ensures the parameters are usable by the consuming function.
 func (params TrackChangeParams) Validate() error {
-	var merr = new(multierror.Error)
+	var merr = multierror.NewPrefixed("plan track change")
 	var emptyDeploymentID = params.DeploymentID == ""
 	var emptyResourceID = params.ResourceID == ""
 	var emptyKind = params.Kind == ""
 
 	if params.API == nil {
-		merr = multierror.Append(merr, errors.New("plan track change: API cannot be nil"))
+		merr = merr.Append(errors.New("API cannot be nil"))
 	}
 
 	if emptyDeploymentID && emptyResourceID {
-		merr = multierror.Append(merr,
-			errors.New("plan track change: one of DeploymentID or ResourceID must be specified"),
+		merr = merr.Append(
+			errors.New("one of DeploymentID or ResourceID must be specified"),
 		)
 	}
 
 	if !emptyDeploymentID && !emptyResourceID {
-		merr = multierror.Append(merr,
-			errors.New("plan track change: cannot specify both DeploymentID and ResourceID"),
+		merr = merr.Append(
+			errors.New("cannot specify both DeploymentID and ResourceID"),
 		)
 	}
 
 	if emptyDeploymentID && emptyKind {
-		merr = multierror.Append(merr,
-			errors.New("plan track change: Kind cannot be empty"),
+		merr = merr.Append(
+			errors.New("kind cannot be empty"),
 		)
 	}
 
-	merr = multierror.Append(merr, params.Config.Validate())
+	merr = merr.Append(params.Config.Validate())
 
 	return merr.ErrorOrNil()
 }
 
 // Validate ensures the parameters are usable by the consuming function.
 func (params *TrackFrequencyConfig) Validate() error {
-	var merr = new(multierror.Error)
+	var merr = multierror.NewPrefixed("plan track change")
 	if params.MaxRetries <= 0 {
-		merr = multierror.Append(merr, errors.New("plan track change: max retries must be at least 1"))
+		merr = merr.Append(errors.New("max retries must be at least 1"))
 	}
 
 	if params.PollFrequency.Nanoseconds() < 1 {
-		merr = multierror.Append(merr, errors.New("plan track change: poll frequency must be at least 1 nanosecond"))
+		merr = merr.Append(errors.New("poll frequency must be at least 1 nanosecond"))
 	}
 	return merr.ErrorOrNil()
 }

--- a/pkg/plan/track_change_test.go
+++ b/pkg/plan/track_change_test.go
@@ -27,10 +27,9 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	planmock "github.com/elastic/cloud-sdk-go/pkg/plan/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
-
-	multierror "github.com/hashicorp/go-multierror"
 )
 
 func TestTrackChange(t *testing.T) {
@@ -338,11 +337,11 @@ func TestTrackChange(t *testing.T) {
 		{
 			name: "errors out on parameter validation",
 			args: args{},
-			err: &multierror.Error{Errors: []error{
-				errors.New("plan track change: API cannot be nil"),
-				errors.New("plan track change: one of DeploymentID or ResourceID must be specified"),
-				errors.New("plan track change: Kind cannot be empty"),
-			}},
+			err: multierror.NewPrefixed("plan track change",
+				errors.New("API cannot be nil"),
+				errors.New("one of DeploymentID or ResourceID must be specified"),
+				errors.New("kind cannot be empty"),
+			),
 		},
 		{
 			name: "errors out when both DeploymentID and ResourceID are specified",
@@ -350,10 +349,10 @@ func TestTrackChange(t *testing.T) {
 				ResourceID:   "cde7b6b605424a54ce9d56316eab13a1",
 				DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38",
 			}},
-			err: &multierror.Error{Errors: []error{
-				errors.New("plan track change: API cannot be nil"),
-				errors.New("plan track change: cannot specify both DeploymentID and ResourceID"),
-			}},
+			err: multierror.NewPrefixed("plan track change",
+				errors.New("API cannot be nil"),
+				errors.New("cannot specify both DeploymentID and ResourceID"),
+			),
 		},
 		{
 			name: "fails looking up the deploymentID",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This change removes all the instances of hashicorp's multierror in favor
of our own multierror package.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Use prefixed multierrors.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
