### PR TITLE
api: Add better API defaults and helpers

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -31,6 +31,10 @@ import (
 )
 
 func TestNewAPI(t *testing.T) {
+	dummyKey, err := auth.NewAPIKey("dummy")
+	if err != nil {
+		t.Fatal(err)
+	}
 	type args struct {
 		c Config
 	}
@@ -44,7 +48,7 @@ func TestNewAPI(t *testing.T) {
 			err: multierror.NewPrefixed("invalid api config",
 				errors.New("client cannot be empty"),
 				errEmptyAuthWriter,
-				errors.New("host cannot be empty"),
+				errESSInvalidAuth,
 			),
 		},
 		{
@@ -67,7 +71,7 @@ func TestNewAPI(t *testing.T) {
 			args: args{c: Config{
 				Host:       "https://cloud.elastic.co",
 				Region:     "us-east-1",
-				AuthWriter: auth.APIKey("dummy"),
+				AuthWriter: dummyKey,
 				VerboseSettings: VerboseSettings{
 					Verbose: true,
 					Device:  output.NewDevice(new(bytes.Buffer)),
@@ -78,8 +82,19 @@ func TestNewAPI(t *testing.T) {
 		{
 			name: "succeeds without region",
 			args: args{c: Config{
-				Host:       "https://cloud.elastic.co",
-				AuthWriter: auth.APIKey("dummy"),
+				Host:       ESSEndpoint,
+				AuthWriter: dummyKey,
+				VerboseSettings: VerboseSettings{
+					Verbose: true,
+					Device:  output.NewDevice(new(bytes.Buffer)),
+				},
+				Client: mock.NewClient(),
+			}},
+		},
+		{
+			name: "succeeds without host",
+			args: args{c: Config{
+				AuthWriter: dummyKey,
 				VerboseSettings: VerboseSettings{
 					Verbose: true,
 					Device:  output.NewDevice(new(bytes.Buffer)),

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -48,7 +48,7 @@ func TestNewAPI(t *testing.T) {
 			err: multierror.NewPrefixed("invalid api config",
 				errors.New("client cannot be empty"),
 				errEmptyAuthWriter,
-				errESSInvalidAuth,
+				errors.New("apikey is the only valid authentication mechanism when targeting the Elasticsearch Service"),
 			),
 		},
 		{

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -31,6 +31,9 @@ import (
 
 var (
 	errEmptyAuthWriter = errors.New("auth writer must not be empty")
+	errESSInvalidAuth  = errors.New(
+		"apikey is the only valid authentication mechanism when targetting the Elasticsearch Service",
+	)
 )
 
 // Config contains the API config
@@ -73,6 +76,12 @@ func (c *Config) Validate() error {
 	merr = merr.Append(checkHost(c.Host))
 	merr = merr.Append(c.VerboseSettings.Validate())
 
+	_, apikeyPtr := c.AuthWriter.(*auth.APIKey)
+	_, apikey := c.AuthWriter.(auth.APIKey)
+	if c.Host == ESSEndpoint && !(apikey || apikeyPtr) {
+		merr = merr.Append(errESSInvalidAuth)
+	}
+
 	return merr.ErrorOrNil()
 }
 
@@ -83,6 +92,10 @@ func (c *Config) fillDefaults() {
 
 	if c.UserAgent == "" {
 		c.UserAgent = DefaultUserAgent
+	}
+
+	if c.Host == "" {
+		c.Host = ESSEndpoint
 	}
 }
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -32,7 +32,7 @@ import (
 var (
 	errEmptyAuthWriter = errors.New("auth writer must not be empty")
 	errESSInvalidAuth  = errors.New(
-		"apikey is the only valid authentication mechanism when targetting the Elasticsearch Service",
+		"apikey is the only valid authentication mechanism when targeting the Elasticsearch Service",
 	)
 )
 

--- a/pkg/api/deploymentapi/deploymentsize/sizes.go
+++ b/pkg/api/deploymentapi/deploymentsize/sizes.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deploymentsize
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const minsize = 512
+
+// Parse converts the stringified size notation to an int32 Megabyte value.
+// The minimum size allowed is 512 Megabytes.
+func Parse(strSize string) (int32, error) {
+	re := regexp.MustCompile(`(?m)(.*\w)(g|m)`)
+	matches := re.FindStringSubmatch(strings.ToLower(strSize))
+	if len(matches) < 2 {
+		fmt.Println(matches, "length", len(matches))
+		return 0, fmt.Errorf(`failed to convert "%s" to <size><g|m>`, strSize)
+	}
+
+	// Pops the first item out when the first match (all groups) are contained
+	// within the full string.
+	if strings.Contains(strSize, matches[0]) {
+		matches = matches[1:]
+	}
+
+	var size int32
+	sizeBody, sizeUnit := matches[0], matches[1]
+
+	rawSize, err := strconv.ParseFloat(sizeBody, 32)
+	if err != nil {
+		return 0, err
+	}
+
+	switch sizeUnit {
+	case "g":
+		size = int32(rawSize * 1024)
+	case "m":
+		size = int32(rawSize)
+	}
+
+	if size < minsize {
+		return 0, fmt.Errorf(`size %d is invalid, minimum size is %d`, size, minsize)
+	}
+
+	return size, nil
+}

--- a/pkg/api/deploymentapi/deploymentsize/sizes_test.go
+++ b/pkg/api/deploymentapi/deploymentsize/sizes_test.go
@@ -1,0 +1,89 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deploymentsize
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	type args struct {
+		strSize string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int32
+		err  error
+	}{
+		{
+			name: "parses a 0.5g (gigabyte notation)",
+			args: args{strSize: "0.5g"}, want: 512,
+		},
+		{
+			name: "parses a 0.75g (gigabyte notation)",
+			args: args{strSize: "0.75g"}, want: 768,
+		},
+		{
+			name: "parses a 8gb (gigabyte notation)",
+			args: args{strSize: "8gb"}, want: 8 * 1024,
+		},
+		{
+			name: "parses a 512mb (megabyte notation)",
+			args: args{strSize: "512mb"}, want: 512,
+		},
+		{
+			name: "parses a 2048mb (megabyte notation)",
+			args: args{strSize: "2048mb"}, want: 2048,
+		},
+		{
+			name: "empty string returns an error",
+			err:  errors.New(`failed to convert "" to <size><g|m>`),
+		},
+		{
+			name: "unknown unit returns an error",
+			args: args{strSize: "9999w"},
+			err:  errors.New(`failed to convert "9999w" to <size><g|m>`),
+		},
+		{
+			name: "invalid  prefix unit returns an error",
+			args: args{strSize: "hellog"},
+			err:  &strconv.NumError{Func: "ParseFloat", Num: "hello", Err: errors.New("invalid syntax")},
+		},
+		{
+			name: "invalid size 0.25g (too small)",
+			args: args{strSize: "0.25g"},
+			err:  errors.New("size 256 is invalid, minimum size is 512"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.args.strSize)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Parse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/api/deploymentapi/request_id.go
+++ b/pkg/api/deploymentapi/request_id.go
@@ -15,27 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package ec
+package deploymentapi
 
-import "math/rand"
+import "github.com/elastic/cloud-sdk-go/pkg/util/ec"
 
-const letterBytes = "abcdefghijklmnopqrstuvwxyz1234567890"
-
-// RandomResourceID generates a random string of 32 characters which emulates
-// a real Elastic Cloud resource ID.
-func RandomResourceID() string {
-	b := make([]byte, 32)
-	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+// RequestID creates a 64-character string when an empty s tring is provided,
+// or returns the provided string. It is aimed to be used as a helper when
+// creating a deployment to always provide a request ID.
+func RequestID(s string) string {
+	if s == "" {
+		return ec.RandomResourceLength(64)
 	}
-	return string(b)
-}
-
-// RandomResourceLength generates a random string of n characters.
-func RandomResourceLength(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
-	}
-	return string(b)
+	return s
 }

--- a/pkg/api/deploymentapi/request_id_test.go
+++ b/pkg/api/deploymentapi/request_id_test.go
@@ -15,27 +15,35 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package ec
+package deploymentapi
 
-import "math/rand"
+import "testing"
 
-const letterBytes = "abcdefghijklmnopqrstuvwxyz1234567890"
-
-// RandomResourceID generates a random string of 32 characters which emulates
-// a real Elastic Cloud resource ID.
-func RandomResourceID() string {
-	b := make([]byte, 32)
-	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+func TestRequestID(t *testing.T) {
+	type args struct {
+		s string
 	}
-	return string(b)
-}
-
-// RandomResourceLength generates a random string of n characters.
-func RandomResourceLength(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+	tests := []struct {
+		name   string
+		args   args
+		length int
+	}{
+		{
+			name:   "returns the passed string",
+			args:   args{s: "some"},
+			length: 4,
+		},
+		{
+			name:   "generates a request ID",
+			args:   args{s: ""},
+			length: 64,
+		},
 	}
-	return string(b)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RequestID(tt.args.s); len(got) != tt.length {
+				t.Errorf("RequestID() = %v, want %v", len(got), tt.length)
+			}
+		})
+	}
 }

--- a/pkg/api/ess.go
+++ b/pkg/api/ess.go
@@ -15,27 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package ec
+package api
 
-import "math/rand"
-
-const letterBytes = "abcdefghijklmnopqrstuvwxyz1234567890"
-
-// RandomResourceID generates a random string of 32 characters which emulates
-// a real Elastic Cloud resource ID.
-func RandomResourceID() string {
-	b := make([]byte, 32)
-	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
-	}
-	return string(b)
-}
-
-// RandomResourceLength generates a random string of n characters.
-func RandomResourceLength(n int) string {
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
-	}
-	return string(b)
-}
+// ESSEndpoint is the Elasticsearch Service endpoint.
+const ESSEndpoint = "https://api.elastic-cloud.com"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This changes the constructor behavior of `NewAPI` and the `Config`
validation now only accepts an `auth.APIKey` or `*auth.APIKey` as the
only valid AuthWriter's for the API when the host is set to the ESS host
(`https://api.elastic-cloud.com`). Also adds a constant: `ESSEndpoint`.

Additionally, adds a new function to the `deploymentapi` package:
`deploymentapi.RequestID`, which will always return a request ID to be
used in `deploymentapi.CreateParams`. It will either return an auto-
generated string of 64 characters or the string argument which is passed
to the function.

Last, it adds a new package called `deploymentsize` and a new function:
`Parse` which will parse a string in the format of `<size><unit`, valid
examples of parseable sizes are:

    * Gigabyte: `10g`, `0.5G`, `16gb`.
    * Megabyte: `1024m`, `2048mb`, `512m`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better defaults for SDK consumers.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
