### PR TITLE
ec: Seed random so randoms actually are random

### DIFF
--- a/pkg/util/ec/rand.go
+++ b/pkg/util/ec/rand.go
@@ -17,16 +17,21 @@
 
 package ec
 
-import "math/rand"
+import (
+	"math/rand"
+	"time"
+)
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyz1234567890"
+
+var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // RandomResourceID generates a random string of 32 characters which emulates
 // a real Elastic Cloud resource ID.
 func RandomResourceID() string {
 	b := make([]byte, 32)
 	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+		b[i] = letterBytes[seededRand.Int63()%int64(len(letterBytes))]
 	}
 	return string(b)
 }
@@ -35,7 +40,7 @@ func RandomResourceID() string {
 func RandomResourceLength(n int) string {
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = letterBytes[rand.Int63()%int64(len(letterBytes))]
+		b[i] = letterBytes[seededRand.Int63()%int64(len(letterBytes))]
 	}
 	return string(b)
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This patchs fixes a bug where the random strings generated the random
string functions in the `ec` package weren't seeded so the randomized
strings returned were pretty consistent and not random.
    * `ec.RandomResourceID()`
    * `ec.RandomResourceLength(<length>)`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Random functions should generate random data!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Adding some unit tests.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
