### PR TITLE
deploymentsize: change Parse to only accept g

### DIFF
--- a/pkg/api/deploymentapi/deploymentsize/sizes.go
+++ b/pkg/api/deploymentapi/deploymentsize/sizes.go
@@ -26,9 +26,9 @@ import (
 
 const minsize = 512
 
-// Parse converts the stringified gigabyte size notation to an int32 Megabyte
+// ParseGb converts the stringified gigabyte size notation to an int32 Megabyte
 // notation. The minimum size allowed is 0.5g Megabytes with 0.5g increments.
-func Parse(strSize string) (int32, error) {
+func ParseGb(strSize string) (int32, error) {
 	re := regexp.MustCompile(`(?m)(.*\w)(g)`)
 	matches := re.FindStringSubmatch(strings.ToLower(strSize))
 	if len(matches) < 2 {

--- a/pkg/api/deploymentapi/deploymentsize/sizes.go
+++ b/pkg/api/deploymentapi/deploymentsize/sizes.go
@@ -49,7 +49,7 @@ func Parse(strSize string) (int32, error) {
 
 	var size = int32(rawSize * 1024)
 	if size < minsize {
-		return 0, fmt.Errorf(`size "%s" is invalid: minimum size is %.1fg`, strSize, float32(float32(minsize)/1024))
+		return 0, fmt.Errorf(`size "%s" is invalid: minimum size is %.1fg`, strSize, float32(minsize)/1024)
 	}
 
 	if size%512 > 0 {

--- a/pkg/api/deploymentapi/deploymentsize/sizes_test.go
+++ b/pkg/api/deploymentapi/deploymentsize/sizes_test.go
@@ -74,7 +74,7 @@ func TestParse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := Parse(tt.args.strSize)
+			got, err := ParseGb(tt.args.strSize)
 			if !reflect.DeepEqual(err, tt.err) {
 				t.Errorf("Parse() error = %v, wantErr %v", err, tt.err)
 				return

--- a/pkg/api/deploymentapi/deploymentsize/sizes_test.go
+++ b/pkg/api/deploymentapi/deploymentsize/sizes_test.go
@@ -39,29 +39,27 @@ func TestParse(t *testing.T) {
 			args: args{strSize: "0.5g"}, want: 512,
 		},
 		{
-			name: "parses a 0.75g (gigabyte notation)",
-			args: args{strSize: "0.75g"}, want: 768,
-		},
-		{
 			name: "parses a 8gb (gigabyte notation)",
 			args: args{strSize: "8gb"}, want: 8 * 1024,
 		},
 		{
-			name: "parses a 512mb (megabyte notation)",
-			args: args{strSize: "512mb"}, want: 512,
+			name: "trying to parse 512m returns a failure",
+			args: args{strSize: "512m"},
+			err:  errors.New(`failed to convert "512m" to <size><g>`),
 		},
 		{
-			name: "parses a 2048mb (megabyte notation)",
-			args: args{strSize: "2048mb"}, want: 2048,
+			name: "trying to parse 0.75g returns a failure",
+			args: args{strSize: "0.75g"},
+			err:  errors.New(`size "0.75g" is invalid: only increments of 0.5g are permitted`),
 		},
 		{
 			name: "empty string returns an error",
-			err:  errors.New(`failed to convert "" to <size><g|m>`),
+			err:  errors.New(`failed to convert "" to <size><g>`),
 		},
 		{
 			name: "unknown unit returns an error",
 			args: args{strSize: "9999w"},
-			err:  errors.New(`failed to convert "9999w" to <size><g|m>`),
+			err:  errors.New(`failed to convert "9999w" to <size><g>`),
 		},
 		{
 			name: "invalid  prefix unit returns an error",
@@ -71,7 +69,7 @@ func TestParse(t *testing.T) {
 		{
 			name: "invalid size 0.25g (too small)",
 			args: args{strSize: "0.25g"},
-			err:  errors.New("size 256 is invalid, minimum size is 512"),
+			err:  errors.New(`size "0.25g" is invalid: minimum size is 0.5g`),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Changes the Parse code to only be able to parse the Gigabyte notation
with 0.5g increments allowed, meaning that only 0.5, 1gb, 1.5gb, etc are
accepted.
