### PR TITLE
api: Fix transport error on UserAgentTransport

### DIFF
--- a/pkg/api/http_transport.go
+++ b/pkg/api/http_transport.go
@@ -26,7 +26,7 @@ import (
 	"time"
 )
 
-const transportCastErrFmt = "transport: failed converting %T to *http.Transport"
+const transportCastErrFmt = "http transport warning: failed converting %T to *http.Transport\n"
 
 var (
 	// DefaultTimeout is used when TransportConfig.Transport is not specified.
@@ -93,6 +93,8 @@ func NewTransport(rt http.RoundTripper, cfg TransportConfig) http.RoundTripper {
 		rt = t
 	case *DebugTransport:
 		return NewUserAgentTransport(t, cfg.UserAgent)
+	case *UserAgentTransport:
+		return t
 	default:
 		if cfg.ErrorDevice != nil {
 			fmt.Fprintf(cfg.ErrorDevice, transportCastErrFmt, rt)

--- a/pkg/api/http_transport_test.go
+++ b/pkg/api/http_transport_test.go
@@ -76,7 +76,18 @@ func TestNewTransport(t *testing.T) {
 				},
 				rt: new(mockRT),
 			},
-			want: "transport: failed converting *api.mockRT to *http.Transport",
+			want: "http transport warning: failed converting *api.mockRT to *http.Transport\n",
+		},
+		{
+			name: "Receives no error when the UserAgentTransport",
+			args: args{
+				buf: new(bytes.Buffer),
+				cfg: TransportConfig{
+					VerboseSettings: VerboseSettings{Verbose: true},
+					SkipTLSVerify:   true,
+				},
+				rt: new(UserAgentTransport),
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This patch adds the case where a UserAgentTransport is passed to the
function. Previously, it was writing an error to the ErrorDevice.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes a small "bug" where an error is printed out.
