### PR TITLE
deploymentapi: Allow overrides on Update operation

### DIFF
--- a/pkg/api/deploymentapi/create.go
+++ b/pkg/api/deploymentapi/create.go
@@ -35,7 +35,8 @@ type CreateParams struct {
 
 	RequestID string
 
-	// deployment Overrides
+	// PayloadOverrides are used as a definition of values which want to
+	// be overriden within the resources themselves.
 	Overrides *PayloadOverrides
 }
 

--- a/pkg/api/deploymentapi/create.go
+++ b/pkg/api/deploymentapi/create.go
@@ -36,7 +36,7 @@ type CreateParams struct {
 	RequestID string
 
 	// PayloadOverrides are used as a definition of values which want to
-	// be overriden within the resources themselves.
+	// be overridden within the resources themselves.
 	Overrides *PayloadOverrides
 }
 

--- a/pkg/api/deploymentapi/update.go
+++ b/pkg/api/deploymentapi/update.go
@@ -39,7 +39,7 @@ type UpdateParams struct {
 	HidePrunedOrphans bool
 
 	// PayloadOverrides are used as a definition of values which want to
-	// be overriden within the resources themselves.
+	// be overridden within the resources themselves.
 	Overrides PayloadOverrides
 }
 

--- a/pkg/api/deploymentapi/update.go
+++ b/pkg/api/deploymentapi/update.go
@@ -38,9 +38,9 @@ type UpdateParams struct {
 	SkipSnapshot      bool
 	HidePrunedOrphans bool
 
-	// Region is an optional value which if set and the the Request.Resources
-	// are missing a region, it populates that field with the value of Region.
-	Region string
+	// PayloadOverrides are used as a definition of values which want to
+	// be overriden within the resources themselves.
+	Overrides PayloadOverrides
 }
 
 // Validate ensures the parameters are usable by Update.
@@ -72,7 +72,7 @@ func Update(params UpdateParams) (*models.DeploymentUpdateResponse, error) {
 		return nil, err
 	}
 
-	setOverrides(params.Request, &PayloadOverrides{Region: params.Region})
+	setOverrides(params.Request, &params.Overrides)
 
 	res, err := params.V1API.Deployments.UpdateDeployment(
 		deployments.NewUpdateDeploymentParams().


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This patch modifies the Update function parameters to allow the consumer
to specify a PayloadOverrides which can be used to override nested
values in the resources. Currently supports Version, Name and Region.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows upgrading all of the deployment's resources using a centralized version.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
