### PR TITLE
api: Use http.Transport.Clone() for new transports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloud-sdk-go
 
-go 1.12
+go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,6 @@ github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsd
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=
 github.com/go-openapi/spec v0.19.3 h1:0XRyw8kguri6Yw4SxhsQA/atC88yqrk0+G4YhI2wabc=
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
-github.com/go-openapi/spec v0.19.7 h1:0xWSeMd35y5avQAThZR2PkEuqSosoS5t6gDH4L8n11M=
-github.com/go-openapi/spec v0.19.7/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/spec v0.19.8 h1:qAdZLh1r6QF/hI/gTq+TJTvsQUodZsM7KLqkAJdiJNg=
 github.com/go-openapi/spec v0.19.8/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=

--- a/pkg/api/http_transport.go
+++ b/pkg/api/http_transport.go
@@ -58,18 +58,14 @@ func newDefaultTransport(timeout time.Duration) *http.Transport {
 		timeout = DefaultTimeout
 	}
 
-	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   timeout,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}
+	var transport = http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+		DualStack: true,
+	}).DialContext
+
+	return transport
 }
 
 // NewTransport constructs a new http.RoundTripper from its config. If rt is
@@ -79,8 +75,6 @@ func newDefaultTransport(timeout time.Duration) *http.Transport {
 // outgoing requests.
 func NewTransport(rt http.RoundTripper, cfg TransportConfig) http.RoundTripper {
 	if rt == nil {
-		// Change this to use the new .Clone() method once Go 1.13+ is
-		// released. See https://github.com/golang/go/issues/26013.
 		rt = newDefaultTransport(cfg.Timeout)
 	}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This patch removes the todo comment on the http.Transport constructor to
use the built-in `.Clone()` method introduced in Go 1.13. It also bumps
the required Go version in go.mod to `1.13`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Use built-in Clone rather than a copy of the http.DefaultTransport settings.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
