### PR TITLE
mock: Add ability to assert received *http.Request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.4.0
 )
 
 replace sourcegraph.com/sourcegraph/go-diff v0.5.1 => github.com/sourcegraph/go-diff v0.5.1

--- a/pkg/api/mock/client.go
+++ b/pkg/api/mock/client.go
@@ -19,7 +19,6 @@ package mock
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -100,16 +99,15 @@ func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		)
 	}
 
-	// Consume and close the body.
-	if req.Body != nil {
-		//nolint
-		ioutil.ReadAll(req.Body)
-		defer req.Body.Close()
-	}
-
 	r := rt.Responses[iteration]
 	if r.Error != nil {
 		return nil, r.Error
+	}
+
+	if r.Assert != nil {
+		if err := AssertRequest(r.Assert, req); err != nil {
+			return nil, err
+		}
 	}
 
 	return &r.Response, nil

--- a/pkg/api/mock/request.go
+++ b/pkg/api/mock/request.go
@@ -1,0 +1,76 @@
+package mock
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// RequestAssertion is used to assert the contents of the request passed to an
+// http.RoundTripper.
+type RequestAssertion struct {
+	Body   io.ReadCloser
+	Header http.Header
+	Method string
+	Path   string
+	Host   string
+}
+
+// AssertRequest ensures that a RequestAssertion matches certain *http.Request
+// fields. If they do not match, an error is return.
+func AssertRequest(want *RequestAssertion, req *http.Request) error {
+	var merr = multierror.NewPrefixed("request assertion")
+	if req.Body != nil || want.Body != nil {
+		if !reflect.DeepEqual(want.Body, req.Body) {
+			var wantB []byte
+			if want.Body != nil {
+				wantB, _ = ioutil.ReadAll(
+					io.TeeReader(want.Body, new(bytes.Buffer)),
+				)
+			}
+			var gotB []byte
+			if req.Body != nil {
+				gotB, _ = ioutil.ReadAll(
+					io.TeeReader(req.Body, new(bytes.Buffer)),
+				)
+			}
+			if !reflect.DeepEqual(wantB, gotB) {
+				merr = merr.Append(
+					fmt.Errorf("got body %s, want %s", gotB, wantB),
+				)
+			}
+
+		}
+	}
+
+	if !reflect.DeepEqual(want.Header, req.Header) {
+		merr = merr.Append(fmt.Errorf(
+			"headers do not match: %v != %v", want.Header, req.Header),
+		)
+	}
+
+	if !reflect.DeepEqual(want.Method, req.Method) {
+		merr = merr.Append(fmt.Errorf(
+			"methods do not match: %s != %s", want.Method, req.Method),
+		)
+	}
+
+	if req.URL != nil && !reflect.DeepEqual(want.Path, req.URL.Path) {
+		merr = merr.Append(fmt.Errorf(
+			"paths do not match: %s != %s", want.Path, req.URL.Path),
+		)
+	}
+
+	if !reflect.DeepEqual(want.Host, req.Host) {
+		merr = merr.Append(fmt.Errorf(
+			"hosts do not match: %s != %s", want.Host, req.Host),
+		)
+	}
+
+	return merr.ErrorOrNil()
+}

--- a/pkg/api/mock/request.go
+++ b/pkg/api/mock/request.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package mock
 
 import (
@@ -44,7 +61,6 @@ func AssertRequest(want *RequestAssertion, req *http.Request) error {
 					fmt.Errorf("got body %s, want %s", gotB, wantB),
 				)
 			}
-
 		}
 	}
 

--- a/pkg/api/mock/request_test.go
+++ b/pkg/api/mock/request_test.go
@@ -1,0 +1,113 @@
+package mock
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssertRequest(t *testing.T) {
+	type args struct {
+		want *RequestAssertion
+		req  *http.Request
+	}
+	tests := []struct {
+		name string
+		args args
+		err  error
+	}{
+		{
+			name: "expects a body but finds none",
+			args: args{
+				want: &RequestAssertion{
+					Body: NewStringBody(`{"some field":1}`),
+				},
+				req: &http.Request{},
+			},
+			err: multierror.NewPrefixed("request assertion",
+				errors.New(`got body , want {"some field":1}`),
+			),
+		},
+		{
+			name: "matches all fields",
+			args: args{
+				want: &RequestAssertion{
+					Body: NewStringBody(`{"some field":1}`),
+					Header: map[string][]string{
+						"Authorization": {"Apikey Someapikey"},
+						"Content-Type":  {"application/json"},
+					},
+					Method: "POST",
+					Host:   "somehost",
+					Path:   "/somepath/somesubpath",
+				},
+				req: &http.Request{
+					Header: map[string][]string{
+						"Authorization": {"Apikey Someapikey"},
+						"Content-Type":  {"application/json"},
+					},
+					Body: NewStringBody(`{"some field":1}`),
+					URL: &url.URL{
+						Path: "/somepath/somesubpath",
+						Host: "somehost",
+					},
+					Host:   "somehost",
+					Method: "POST",
+				},
+			},
+		},
+		{
+			name: "matches no fields, returns an error",
+			args: args{
+				want: &RequestAssertion{
+					Body: NewStringBody(`{"some field":2}`),
+					Header: map[string][]string{
+						"Content-Type": {"application/json"},
+					},
+					Method: "GET",
+					Host:   "someotherhost",
+					Path:   "/someotherpath/somesubpath",
+				},
+				req: &http.Request{
+					Header: map[string][]string{
+						"Authorization": {"Apikey Someapikey"},
+						"Content-Type":  {"application/json"},
+					},
+					Body: NewStringBody(`{"some field":1}`),
+					URL: &url.URL{
+						Path: "/somepath/somesubpath",
+						Host: "somehost",
+					},
+					Host:   "somehost",
+					Method: "POST",
+				},
+			},
+			err: multierror.NewPrefixed("request assertion",
+				errors.New(`got body {"some field":1}, want {"some field":2}`),
+				errors.New(`headers do not match: map[Content-Type:[application/json]] != map[Authorization:[Apikey Someapikey] Content-Type:[application/json]]`),
+				errors.New(`methods do not match: GET != POST`),
+				errors.New(`paths do not match: /someotherpath/somesubpath != /somepath/somesubpath`),
+				errors.New(`hosts do not match: someotherhost != somehost`),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := AssertRequest(tt.args.want, tt.args.req)
+			var errString string
+			if tt.err != nil {
+				errString = tt.err.Error()
+			}
+			if err != nil || errString != "" {
+				assert.EqualError(t, err, errString)
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/api/mock/request_test.go
+++ b/pkg/api/mock/request_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package mock
 
 import (
@@ -6,8 +23,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 )
 
 func TestAssertRequest(t *testing.T) {

--- a/pkg/api/mock/response.go
+++ b/pkg/api/mock/response.go
@@ -31,6 +31,10 @@ import (
 type Response struct {
 	Response http.Response
 	Error    error
+
+	// If specified, it'll assert that the received request's fields match
+	// the assertion.
+	Assert *RequestAssertion
 }
 
 // NewStringBody creates an io.ReadCloser from a string.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This patch adds the ability to assert certain *http.Request fields which
are sent to the http.RoundTripper on any of the request / reply flows
which are tested and asserted in our unit tests.

Adds the ability to assert what's sent over to the API so our unit tests
become more complete. Since it's an optional field, it doesn't enforce
that field to be set in the `mock.Response`, but rather make it optional
for those tests where it makes sense to do so.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ability to assert outgoing http.Request sent by the SDK.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Via unit tests
