### PR TITLE
api: transport now handles raw metadata producer

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v1.3.0 h1:iDwIio/3gk2QtLLEsqU5lInaMzos0hDTz8a6lazSFVw=
-github.com/mitchellh/mapstructure v1.3.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.3.1 h1:cCBH2gTD2K0OtLlv/Y5H01VQCqmlDxz30kS5Y5bqfLA=
 github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/pkg/api/client_runtime.go
+++ b/pkg/api/client_runtime.go
@@ -93,7 +93,7 @@ func (r *CloudClientRuntime) getRuntime(op *runtime.ClientOperation) *runtimecli
 	return r.regionRuntime
 }
 
-// overrideJSONProducer will override the default JSON producer fucntion for
+// overrideJSONProducer will override the default JSON producer function for
 // a Text producer which won't to serialize the data to JSON, and just send
 // the body as is over the wire. This is useful in cases where a JSON body is
 // being sent as a Go string value, not doing this will cause the payload json

--- a/pkg/api/client_runtime.go
+++ b/pkg/api/client_runtime.go
@@ -93,6 +93,13 @@ func (r *CloudClientRuntime) getRuntime(op *runtime.ClientOperation) *runtimecli
 	return r.regionRuntime
 }
 
+// overrideJSONProducer will override the default JSON producer fucntion for
+// a Text producer which won't to serialize the data to JSON, and just send
+// the body as is over the wire. This is useful in cases where a JSON body is
+// being sent as a Go string value, not doing this will cause the payload json
+// quotes to be escaped. See unit tests for examples.
+// It returns a function which can be used as a callback to reset the producer
+// to its original value.
 func overrideJSONProducer(r *runtimeclient.Runtime, opID string) func() {
 	if opID != rawMetadataTextProducer {
 		return func() {}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a conditional which checks that if the set raw metadata endpoint is
called, then the producer is substituted from JSON to Text in order to
be able to send a string as a JSON object without escaping the quotes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Handle the set-Elasticsearch raw metadata operation natively

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests and tested mocking the SDK.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
