### PR TITLE
api: NewMock now uses NewAPI as the constructor

### DIFF
--- a/pkg/api/deploymentapi/resync_test.go
+++ b/pkg/api/deploymentapi/resync_test.go
@@ -77,7 +77,7 @@ func TestResync(t *testing.T) {
 			}},
 			wantErr: &url.Error{
 				Op:  "Post",
-				URL: "https://mock-host/mock-path/deployments/2c221bd86b7f48959a59ee3128d5c5e8/_resync",
+				URL: "https://mock.elastic.co/api/v1/deployments/2c221bd86b7f48959a59ee3128d5c5e8/_resync",
 				Err: errors.New("error with API"),
 			},
 		},
@@ -136,7 +136,7 @@ func TestResyncAll(t *testing.T) {
 			}},
 			wantErr: &url.Error{
 				Op:  "Post",
-				URL: "https://mock-host/mock-path/deployments/_resync",
+				URL: "https://mock.elastic.co/api/v1/deployments/_resync",
 				Err: errors.New("error with API"),
 			},
 		},

--- a/pkg/auth/testutil.go
+++ b/pkg/auth/testutil.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	defaultMockSchema = []string{"https"}
-	defaultMockHost   = "mock-host"
+	defaultMockHost   = "mock.elastic.co"
 	defaultMockPath   = "mock-path"
 )
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Changes the way that `api.NewMock` creates the *API struct. Instead of
creating the API struct directly, it uses the constructor api.NewAPI so
all our tests can replicate more closely what is run on in real life.

This patch will cause any unit test which assert any API path error to
fail, since it changes the basepath to `mock.elastic.co` and uses the
suffix `/api/v1` instead of a bogus one.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Having better unit tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Via our unit tests.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
