### PR TITLE
api: Add RedactAuth bool option to VerboseSettings

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -103,6 +103,10 @@ func (c *Config) fillDefaults() {
 type VerboseSettings struct {
 	Verbose bool
 	Device  io.Writer
+
+	// RedactAuth replaces the contents of the Authorization header with:
+	// "[REDACTED]".
+	RedactAuth bool
 }
 
 // Validate ensures the settings are usable.

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -101,8 +101,8 @@ func (c *Config) fillDefaults() {
 
 // VerboseSettings define the behaviour of verbosity.
 type VerboseSettings struct {
-	Verbose bool
 	Device  io.Writer
+	Verbose bool
 
 	// RedactAuth replaces the contents of the Authorization header with:
 	// "[REDACTED]".

--- a/pkg/api/debug_test.go
+++ b/pkg/api/debug_test.go
@@ -26,8 +26,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 )
 
 func TestNewDebugTransport(t *testing.T) {

--- a/pkg/api/http_transport.go
+++ b/pkg/api/http_transport.go
@@ -97,7 +97,7 @@ func NewTransport(rt http.RoundTripper, cfg TransportConfig) http.RoundTripper {
 
 	if cfg.Verbose {
 		return NewUserAgentTransport(
-			NewDebugTransport(rt, cfg.Device), cfg.UserAgent,
+			NewDebugTransport(rt, cfg.Device, cfg.RedactAuth), cfg.UserAgent,
 		)
 	}
 


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Adds a new configuration parameter `RedactAuth` to `api.VerboseSettings`
which if set, will replace the contents of the `Authorization` header
with [REDACTED].

The default behavior still preserves the original contents of the
header.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #110 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
