### PR TITLE
api: Export default mock headers and host

### DIFF
--- a/pkg/api/mock.go
+++ b/pkg/api/mock.go
@@ -26,10 +26,27 @@ import (
 )
 
 var (
-	defaultMockSchema = "https"
-	defaultMockHost   = "mock.elastic.co"
+	// DefaultWriteMockHeaders can be used for test assertions.
+	DefaultWriteMockHeaders = map[string][]string{
+		"Accept":        {"application/json"},
+		"Authorization": {"ApiKey dummy"},
+		"Content-Type":  {"application/json"},
+		"User-Agent":    {fmt.Sprint("cloud-sdk-go/", Version)},
+	}
 
-	mockSchemaHost = fmt.Sprintf("%s://%s", defaultMockSchema, defaultMockHost)
+	// DefaultReadMockHeaders can be used for test assertions.
+	DefaultReadMockHeaders = map[string][]string{
+		"Accept":        {"application/json"},
+		"Authorization": {"ApiKey dummy"},
+		"User-Agent":    {fmt.Sprint("cloud-sdk-go/", Version)},
+	}
+
+	// DefaultMockHost can be used for test assertions
+	DefaultMockHost = "mock.elastic.co"
+
+	defaultMockSchema = "https"
+
+	mockSchemaHost = fmt.Sprintf("%s://%s", defaultMockSchema, DefaultMockHost)
 )
 
 // NewMock creates a new api.API from a list of Responses. Defaults to a dummy


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Exports three new variables:

    * DefaultWriteMockHeaders
    * DefaultReadMockHeaders
    * DefaultMockHost

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Part of #129 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Easier request assertions.
