### PR TITLE
roleapi: Add Region field and WithRegion ctx

### DIFF
--- a/pkg/api/mock/response.go
+++ b/pkg/api/mock/response.go
@@ -97,6 +97,61 @@ func New500Response(body io.ReadCloser) Response {
 	}}
 }
 
+// New200ResponseAssertion creates a new response with request assertion and a statuscode 200
+func New200ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Response {
+	return Response{
+		Response: http.Response{
+			StatusCode: 200,
+			Body:       populateBody(body),
+		},
+		Assert: assertion,
+	}
+}
+
+// New201ResponseAssertion creates a new response with request assertion and a statuscode 201
+func New201ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Response {
+	return Response{
+		Response: http.Response{
+			StatusCode: 201,
+			Body:       populateBody(body),
+		},
+		Assert: assertion,
+	}
+}
+
+// New202ResponseAssertion creates a new response with request assertion and a statuscode 202
+func New202ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Response {
+	return Response{
+		Response: http.Response{
+			StatusCode: 202,
+			Body:       populateBody(body),
+		},
+		Assert: assertion,
+	}
+}
+
+// New404ResponseAssertion creates a new response with request assertion and a statuscode 404
+func New404ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Response {
+	return Response{
+		Response: http.Response{
+			StatusCode: 404,
+			Body:       populateBody(body),
+		},
+		Assert: assertion,
+	}
+}
+
+// New500ResponseAssertion creates a new response with request assertion and a statuscode 500
+func New500ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Response {
+	return Response{
+		Response: http.Response{
+			StatusCode: 500,
+			Body:       populateBody(body),
+		},
+		Assert: assertion,
+	}
+}
+
 func populateBody(body io.ReadCloser) io.ReadCloser {
 	if body == nil {
 		return NewStringBody("")

--- a/pkg/api/mock/response_test.go
+++ b/pkg/api/mock/response_test.go
@@ -20,9 +20,21 @@ package mock
 import (
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 )
+
+var mockRequestAssertion = &RequestAssertion{
+	Header: map[string][]string{"Accept": {"application/json"}},
+	Method: "DELETE",
+	Host:   "mock.elastic.co",
+	Path:   "/api/v1",
+	Query: url.Values{
+		"some_value": []string{"false"},
+	},
+	Body: NewStringBody(`{}` + "\n"),
+}
 
 func TestNew200Response(t *testing.T) {
 	bodyBuffer := NewStringBody("200")
@@ -208,6 +220,271 @@ func TestNew500Response(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := New500Response(tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New500Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew200ResponseAssertion(t *testing.T) {
+	bodyBuffer := NewStringBody("200")
+	type args struct {
+		assertion *RequestAssertion
+		body      io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 200",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 200,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 200 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 200,
+				Body:       bodyBuffer,
+			}},
+		},
+		{
+			name: "Returns statuscode 200 with body and request assertion",
+			args: args{
+				assertion: mockRequestAssertion,
+				body:      bodyBuffer,
+			},
+			want: Response{
+				Response: http.Response{
+					StatusCode: 200,
+					Body:       bodyBuffer,
+				},
+				Assert: mockRequestAssertion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New200ResponseAssertion(tt.args.assertion, tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New200Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew201ResponseAssertion(t *testing.T) {
+	bodyBuffer := NewStringBody("201")
+	type args struct {
+		assertion *RequestAssertion
+		body      io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 201",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 201,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 201 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 201,
+				Body:       bodyBuffer,
+			}},
+		},
+		{
+			name: "Returns statuscode 201 with body and request assertion",
+			args: args{
+				assertion: mockRequestAssertion,
+				body:      bodyBuffer,
+			},
+			want: Response{
+				Response: http.Response{
+					StatusCode: 201,
+					Body:       bodyBuffer,
+				},
+				Assert: mockRequestAssertion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New201ResponseAssertion(tt.args.assertion, tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New201Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew202ResponseAssertion(t *testing.T) {
+	bodyBuffer := NewStringBody("202")
+	type args struct {
+		assertion *RequestAssertion
+		body      io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 202",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 202,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 202 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 202,
+				Body:       bodyBuffer,
+			}},
+		},
+		{
+			name: "Returns statuscode 202 with body and request assertion",
+			args: args{
+				assertion: mockRequestAssertion,
+				body:      bodyBuffer,
+			},
+			want: Response{
+				Response: http.Response{
+					StatusCode: 202,
+					Body:       bodyBuffer,
+				},
+				Assert: mockRequestAssertion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New202ResponseAssertion(tt.args.assertion, tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New202Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew404ResponseAssertion(t *testing.T) {
+	bodyBuffer := NewStringBody("404")
+	type args struct {
+		assertion *RequestAssertion
+		body      io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 404",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 404,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 404 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 404,
+				Body:       bodyBuffer,
+			}},
+		},
+		{
+			name: "Returns statuscode 404 with body and request assertion",
+			args: args{
+				assertion: mockRequestAssertion,
+				body:      bodyBuffer,
+			},
+			want: Response{
+				Response: http.Response{
+					StatusCode: 404,
+					Body:       bodyBuffer,
+				},
+				Assert: mockRequestAssertion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New404ResponseAssertion(tt.args.assertion, tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New404Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew500ResponseAssertion(t *testing.T) {
+	bodyBuffer := NewStringBody("500")
+	type args struct {
+		assertion *RequestAssertion
+		body      io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 500",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 500,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 500 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 500,
+				Body:       bodyBuffer,
+			}},
+		},
+		{
+			name: "Returns statuscode 500 with body and request assertion",
+			args: args{
+				assertion: mockRequestAssertion,
+				body:      bodyBuffer,
+			},
+			want: Response{
+				Response: http.Response{
+					StatusCode: 500,
+					Body:       bodyBuffer,
+				},
+				Assert: mockRequestAssertion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New500ResponseAssertion(tt.args.assertion, tt.args.body); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("New500Response() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/api/platformapi/roleapi/add_blessing_test.go
+++ b/pkg/api/platformapi/roleapi/add_blessing_test.go
@@ -19,11 +19,11 @@ package roleapi
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
@@ -41,16 +41,18 @@ func TestAddBlessing(t *testing.T) {
 		{
 			name: "fails on parameter validation",
 			args: args{},
-			err: multierror.NewPrefixed("role add blessing",
-				apierror.ErrMissingAPI,
-				errors.New("blessing definition cannot be empty"),
-				errors.New("id cannot be empty"),
-				errors.New("runner id cannot be empty"),
+			err: multierror.NewPrefixed("invalid role add blessing params",
+				errors.New("api reference is required for the operation"),
+				errors.New("blessing definition not specified and is required for this operation"),
+				errors.New("id not specified and is required for this operation"),
+				errors.New("runner id not specified and is required for this operation"),
+				errors.New("region not specified and is required for this operation"),
 			),
 		},
 		{
 			name: "fails updating the role",
 			args: args{params: AddBlessingParams{
+				Region: "us-east-1",
 				API: api.NewMock(mock.New500Response(mock.NewStringBody(
 					`{"error": "failed updating role"}`,
 				))),
@@ -63,7 +65,17 @@ func TestAddBlessing(t *testing.T) {
 		{
 			name: "succeeds",
 			args: args{params: AddBlessingParams{
-				API:      api.NewMock(mock.New200Response(mock.NewStringBody(""))),
+				Region: "us-east-1",
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "PUT",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/regions/us-east-1/platform/infrastructure/blueprinter/roles/one/blessings/some",
+						Body:   mock.NewStringBody(`{"value":null}` + "\n"),
+					},
+					mock.NewStringBody(""),
+				)),
 				Blessing: &models.Blessing{},
 				ID:       "one",
 				RunnerID: "some",
@@ -72,8 +84,9 @@ func TestAddBlessing(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := AddBlessing(tt.args.params); !reflect.DeepEqual(err, tt.err) {
-				t.Errorf("AddBlessing() error = %v, wantErr %v", err, tt.err)
+			err := AddBlessing(tt.args.params)
+			if !assert.Equal(t, tt.err, err) {
+				t.Error(err)
 			}
 		})
 	}

--- a/pkg/api/platformapi/roleapi/update_test.go
+++ b/pkg/api/platformapi/roleapi/update_test.go
@@ -19,11 +19,11 @@ package roleapi
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
@@ -41,15 +41,17 @@ func TestUpdate(t *testing.T) {
 		{
 			name: "fails on parameter validation",
 			args: args{},
-			err: multierror.NewPrefixed("role update",
-				apierror.ErrMissingAPI,
-				errors.New("role definition cannot be empty"),
-				errors.New("id cannot be empty"),
+			err: multierror.NewPrefixed("invalid role update params",
+				errors.New("api reference is required for the operation"),
+				errors.New("role definition not specified and is required for this operation"),
+				errors.New("id not specified and is required for this operation"),
+				errors.New("region not specified and is required for this operation"),
 			),
 		},
 		{
 			name: "fails updating the role",
 			args: args{params: UpdateParams{
+				Region: "us-east-1",
 				API: api.NewMock(mock.New500Response(mock.NewStringBody(
 					`{"error": "failed updating role"}`,
 				))),
@@ -61,7 +63,17 @@ func TestUpdate(t *testing.T) {
 		{
 			name: "succeeds",
 			args: args{params: UpdateParams{
-				API:  api.NewMock(mock.New200Response(mock.NewStringBody(""))),
+				Region: "us-east-1",
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "PUT",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/regions/us-east-1/platform/infrastructure/blueprinter/roles/one",
+						Body:   mock.NewStringBody(`{"auto_blessed":null,"containers":null,"id":null}` + "\n"),
+					},
+					mock.NewStringBody(""),
+				)),
 				Role: &models.Role{},
 				ID:   "one",
 			}},
@@ -69,8 +81,9 @@ func TestUpdate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := Update(tt.args.params); !reflect.DeepEqual(err, tt.err) {
-				t.Errorf("Update() error = %v, wantErr %v", err, tt.err)
+			err := Update(tt.args.params)
+			if !assert.Equal(t, tt.err, err) {
+				t.Error(err)
 			}
 		})
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This patch modifies all the roleapi public functions to have a
Region string required parameter which is then used to create a new
context.Context: api.WithRegion(context.Background(), params.Region)
and pass it as the API operation context.

Unit tests have been modified to include a request
assertion which ensures that the region path interpolation is used when
the /platform APIs are being called.

Additionally, a few new helper functions have been added that create a new response with request assertion and a statuscode.

## Related Issues
Related: #129 

## How Has This Been Tested?
unit tests in ecctl

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
