### PR TITLE
allocator vacate: Add enterprise search support

### DIFF
--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -430,7 +430,7 @@ func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure
 	}
 
 	if len(req.EnterpriseSearchClusters) > 0 {
-		moveParams.SetClusterType(util.EnterpriseSearch)
+		moveParams.SetClusterType(ec.String(util.EnterpriseSearch))
 	}
 
 	return moveParams, nil

--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -240,6 +240,18 @@ func addAllocatorMovesToPool(params addAllocatorMovesToPoolParams) ([]pool.Valid
 		vacates = append(vacates, newVacateClusterParams(params, *move.ClusterID, kind))
 	}
 
+	for _, move := range params.Moves.EnterpriseSearchClusters {
+		if len(filter) > 0 && !slice.HasString(filter, *move.ClusterID) {
+			continue
+		}
+
+		var kind = util.EnterpriseSearch
+		if kindFilter != "" && kind != kindFilter {
+			break
+		}
+		vacates = append(vacates, newVacateClusterParams(params, *move.ClusterID, kind))
+	}
+
 	if leftover, _ := params.Pool.Add(vacates...); len(leftover) > 0 {
 		leftovers = append(leftovers, leftover...)
 	}
@@ -417,6 +429,10 @@ func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure
 		moveParams.SetClusterType(ec.String(util.Appsearch))
 	}
 
+	if len(req.EnterpriseSearchClusters) > 0 {
+		moveParams.SetClusterType(ec.String(util.EnterpriseSearch))
+	}
+
 	return moveParams, nil
 }
 
@@ -522,6 +538,24 @@ func CheckVacateFailures(failures *models.MoveClustersDetails, filter []string) 
 		}
 	}
 
+	for _, failure := range failures.EnterpriseSearchClusters {
+		if len(filter) > 0 && !slice.HasString(filter, *failure.ClusterID) {
+			continue
+		}
+
+		var ferr error
+		if len(failure.Errors) > 0 {
+			var err = failure.Errors[0]
+			ferr = fmt.Errorf("code: %s, message: %s", *err.Code, *err.Message)
+		}
+
+		if !strings.Contains(ferr.Error(), PlanPendingMessage) {
+			merr = merr.Append(
+				fmt.Errorf("resource id [%s][enterprise_search] failed vacating, reason: %s", *failure.ClusterID, ferr),
+			)
+		}
+	}
+
 	return merr.ErrorOrNil()
 }
 
@@ -592,6 +626,20 @@ func ComputeVacateRequest(pr *models.MoveClustersDetails, clusters, to []string,
 		c.CalculatedPlan.PlanConfiguration.PreferredAllocators = to
 		req.AppsearchClusters = append(req.AppsearchClusters,
 			&models.MoveAppSearchConfiguration{
+				ClusterIds:   []string{*c.ClusterID},
+				PlanOverride: c.CalculatedPlan,
+			},
+		)
+	}
+
+	for _, c := range pr.EnterpriseSearchClusters {
+		if len(clusters) > 0 && !slice.HasString(clusters, *c.ClusterID) {
+			continue
+		}
+
+		c.CalculatedPlan.PlanConfiguration.PreferredAllocators = to
+		req.EnterpriseSearchClusters = append(req.EnterpriseSearchClusters,
+			&models.MoveEnterpriseSearchConfiguration{
 				ClusterIds:   []string{*c.ClusterID},
 				PlanOverride: c.CalculatedPlan,
 			},

--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -562,6 +562,7 @@ func CheckVacateFailures(failures *models.MoveClustersDetails, filter []string) 
 // ComputeVacateRequest filters the tentative cluster that would be moved and
 // filters those by ID if it's specified, also setting any preferred allocators
 // if that is sent. Any cluster plan overrides will be set in this function.
+// nolint due to complexity
 func ComputeVacateRequest(pr *models.MoveClustersDetails, clusters, to []string, overrides PlanOverrides) *models.MoveClustersRequest {
 	var req models.MoveClustersRequest
 	for _, c := range pr.ElasticsearchClusters {

--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -430,7 +430,7 @@ func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure
 	}
 
 	if len(req.EnterpriseSearchClusters) > 0 {
-		moveParams.SetClusterType(ec.String(util.EnterpriseSearch))
+		moveParams.SetClusterType(util.EnterpriseSearch)
 	}
 
 	return moveParams, nil

--- a/pkg/api/platformapi/allocatorapi/vacate_full_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_full_test.go
@@ -215,6 +215,71 @@ func TestVacate(t *testing.T) {
 			),
 		},
 		{
+			name: "Succeeds moving a single Enterprise Search cluster from a single allocator (without tracking)",
+			args: args{
+				buf: sdkSync.NewBuffer(),
+				params: newVacateTestCase(t, vacateCase{
+					region:       "us-east-1",
+					skipTracking: true,
+					topology: []vacateCaseClusters{
+						{
+							Allocator: "allocatorID",
+							EnterpriseSearch: []vacateCaseClusterConfig{
+								{
+									ID: "3ee11eb40eda22cac0cce259625c6734",
+									steps: [][]*models.ClusterPlanStepInfo{
+										{
+											newPlanStep("step1", "success"),
+											newPlanStep("step2", "pending"),
+										},
+									},
+									plan: []*models.ClusterPlanStepInfo{
+										newPlanStep("step1", "success"),
+										newPlanStep("step2", "success"),
+										newPlanStep("plan-completed", "success"),
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+		},
+		{
+			name: "Succeeds moving a single Enterprise Search cluster from a single allocator",
+			args: args{
+				buf: sdkSync.NewBuffer(),
+				params: newVacateTestCase(t, vacateCase{
+					region: "us-east-1",
+					topology: []vacateCaseClusters{
+						{
+							Allocator: "allocatorID",
+							EnterpriseSearch: []vacateCaseClusterConfig{
+								{
+									ID: "3ee11eb40eda22cac0cce259625c6734",
+									steps: [][]*models.ClusterPlanStepInfo{
+										{
+											newPlanStep("step1", "success"),
+											newPlanStep("step2", "pending"),
+										},
+									},
+									plan: []*models.ClusterPlanStepInfo{
+										newPlanStep("step1", "success"),
+										newPlanStep("step2", "success"),
+										newPlanStep("plan-completed", "success"),
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+			want: newOutputResponses(
+				"Deployment [DISCOVERED_DEPLOYMENT_ID] - [Enterprise Search][3ee11eb40eda22cac0cce259625c6734]: running step \"step2\" (Plan duration )...",
+				"\x1b[92;mDeployment [DISCOVERED_DEPLOYMENT_ID] - [Enterprise Search][3ee11eb40eda22cac0cce259625c6734]: finished running all the plan steps\x1b[0m (Total plan duration )",
+			),
+		},
+		{
 			name: "Succeeds moving a multiple clusters from a single allocator",
 			args: args{
 				buf: sdkSync.NewBuffer(),

--- a/pkg/api/platformapi/allocatorapi/vacate_params.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_params.go
@@ -41,7 +41,13 @@ var (
 	errOutputDeviceCannotBeNil      = errors.New("output device cannot be nil")
 	errCannotOverrideAllocatorDown  = errors.New("cannot set the AllocatorDown when multiple allocators are specified")
 
-	allowedClusterKinds = []string{util.Apm, util.Elasticsearch, util.Kibana, util.Appsearch}
+	allowedClusterKinds = []string{
+		util.Apm,
+		util.Appsearch,
+		util.Elasticsearch,
+		util.EnterpriseSearch,
+		util.Kibana,
+	}
 )
 
 // VacateParams used to vacate N allocators or clusters.

--- a/pkg/api/platformapi/allocatorapi/vacate_params_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_params_test.go
@@ -99,6 +99,30 @@ func TestVacateParamsValidate(t *testing.T) {
 			err: nil,
 		},
 		{
+			name: "Accepts a correct set of parameters with an appsearch kind filter",
+			fields: fields{
+				API:         new(api.API),
+				Allocators:  []string{"an allocator"},
+				KindFilter:  util.Appsearch,
+				Concurrency: 1,
+				Output:      new(output.Device),
+				Region:      "us-east-1",
+			},
+			err: nil,
+		},
+		{
+			name: "Accepts a correct set of parameters with an enterprise_search kind filter",
+			fields: fields{
+				API:         new(api.API),
+				Allocators:  []string{"an allocator"},
+				KindFilter:  util.EnterpriseSearch,
+				Concurrency: 1,
+				Output:      new(output.Device),
+				Region:      "us-east-1",
+			},
+			err: nil,
+		},
+		{
 			name:   "Empty parameters are not accepted",
 			fields: fields{},
 			err: multierror.NewPrefixed("invalid allocator vacate params",

--- a/pkg/plan/mock/generator.go
+++ b/pkg/plan/mock/generator.go
@@ -29,10 +29,11 @@ type GenerateConfig struct {
 	// If omitted, a random ID will be auto-generated.
 	ID string
 
-	Elasticsearch []GeneratedResourceConfig
-	Kibana        []GeneratedResourceConfig
-	Apm           []GeneratedResourceConfig
-	Appsearch     []GeneratedResourceConfig
+	Elasticsearch    []GeneratedResourceConfig
+	EnterpriseSearch []GeneratedResourceConfig
+	Kibana           []GeneratedResourceConfig
+	Apm              []GeneratedResourceConfig
+	Appsearch        []GeneratedResourceConfig
 }
 
 // GeneratedResourceConfig is used to construct a deployment resource plan
@@ -64,10 +65,11 @@ func Generate(cfg GenerateConfig) *models.DeploymentGetResponse {
 	return &models.DeploymentGetResponse{
 		ID: ec.String(id),
 		Resources: &models.DeploymentResources{
-			Apm:           generateApmResourceInfo(cfg.Apm),
-			Kibana:        generateKibanaResourceInfo(cfg.Kibana),
-			Elasticsearch: generateElasticsearchResourceInfo(cfg.Elasticsearch),
-			Appsearch:     generateAppSearchResourceInfo(cfg.Appsearch),
+			Apm:              generateApmResourceInfo(cfg.Apm),
+			Kibana:           generateKibanaResourceInfo(cfg.Kibana),
+			Elasticsearch:    generateElasticsearchResourceInfo(cfg.Elasticsearch),
+			Appsearch:        generateAppSearchResourceInfo(cfg.Appsearch),
+			EnterpriseSearch: generateEnterpriseSearchResourceInfo(cfg.EnterpriseSearch),
 		},
 	}
 }
@@ -114,6 +116,31 @@ func generateAppSearchResourceInfo(c []GeneratedResourceConfig) []*models.AppSea
 			Pending: &models.AppSearchPlanInfo{PlanAttemptLog: gen.PendingLog},
 			Current: &models.AppSearchPlanInfo{PlanAttemptLog: gen.CurrentLog},
 			History: []*models.AppSearchPlanInfo{{PlanAttemptLog: gen.HistoryLog}},
+		}}
+
+		resInfo = append(resInfo, &info)
+	}
+
+	return resInfo
+}
+
+func generateEnterpriseSearchResourceInfo(c []GeneratedResourceConfig) []*models.EnterpriseSearchResourceInfo {
+	var resInfo = make([]*models.EnterpriseSearchResourceInfo, 0, len(c))
+	for _, gen := range c {
+		var info models.EnterpriseSearchResourceInfo
+		info.ID = &gen.ID
+		if gen.ID == "" {
+			info.ID = ec.String(ec.RandomResourceID())
+		}
+		info.RefID = &gen.RefID
+		if gen.RefID == "" {
+			info.RefID = ec.String("main-enterprise_search")
+		}
+
+		info.Info = &models.EnterpriseSearchInfo{PlanInfo: &models.EnterpriseSearchPlansInfo{
+			Pending: &models.EnterpriseSearchPlanInfo{PlanAttemptLog: gen.PendingLog},
+			Current: &models.EnterpriseSearchPlanInfo{PlanAttemptLog: gen.CurrentLog},
+			History: []*models.EnterpriseSearchPlanInfo{{PlanAttemptLog: gen.HistoryLog}},
 		}}
 
 		resInfo = append(resInfo, &info)

--- a/pkg/plan/mock/generator_test.go
+++ b/pkg/plan/mock/generator_test.go
@@ -31,6 +31,7 @@ func TestGenerate(t *testing.T) {
 	var esID = ec.RandomResourceID()
 	var kibanaID = ec.RandomResourceID()
 	var appsearchID = ec.RandomResourceID()
+	var enterpriseSearchID = ec.RandomResourceID()
 	var ApmCurrentLog = []*models.ClusterPlanStepInfo{
 		{Stage: ec.String("completed")},
 	}
@@ -43,6 +44,9 @@ func TestGenerate(t *testing.T) {
 	var AppsearchCurrentLog = []*models.ClusterPlanStepInfo{
 		{Stage: ec.String("completed")},
 	}
+	var EnterpriseSearchCurrentLog = []*models.ClusterPlanStepInfo{
+		{Stage: ec.String("completed")},
+	}
 	var ApmPendingLog = []*models.ClusterPlanStepInfo{
 		{Stage: ec.String("in_progress")},
 	}
@@ -53,6 +57,9 @@ func TestGenerate(t *testing.T) {
 		{Stage: ec.String("in_progress")},
 	}
 	var AppsearchPendingLog = []*models.ClusterPlanStepInfo{
+		{Stage: ec.String("in_progress")},
+	}
+	var EnterpriseSearchPendingLog = []*models.ClusterPlanStepInfo{
 		{Stage: ec.String("in_progress")},
 	}
 	type args struct {
@@ -95,6 +102,13 @@ func TestGenerate(t *testing.T) {
 						PendingLog: AppsearchPendingLog,
 					},
 				},
+				EnterpriseSearch: []GeneratedResourceConfig{
+					{
+						ID:         enterpriseSearchID,
+						CurrentLog: EnterpriseSearchCurrentLog,
+						PendingLog: EnterpriseSearchPendingLog,
+					},
+				},
 			}},
 			want: &models.DeploymentGetResponse{
 				ID: ec.String(deploymentID),
@@ -125,6 +139,13 @@ func TestGenerate(t *testing.T) {
 							ID:         appsearchID,
 							CurrentLog: AppsearchCurrentLog,
 							PendingLog: AppsearchPendingLog,
+						},
+					}),
+					EnterpriseSearch: generateEnterpriseSearchResourceInfo([]GeneratedResourceConfig{
+						{
+							ID:         enterpriseSearchID,
+							CurrentLog: EnterpriseSearchCurrentLog,
+							PendingLog: EnterpriseSearchPendingLog,
 						},
 					}),
 				},

--- a/pkg/plan/track_change_test.go
+++ b/pkg/plan/track_change_test.go
@@ -87,6 +87,17 @@ func TestTrackChange(t *testing.T) {
 				),
 			},
 		},
+		EnterpriseSearch: []planmock.GeneratedResourceConfig{
+			{
+				ID: "6de9b2b605424a54ce9d56316eab13a6",
+				PendingLog: planmock.NewPlanStepLog(
+					planmock.NewPlanStep("step-1", "success"),
+					planmock.NewPlanStep("step-2", "success"),
+					planmock.NewPlanStep("step-3", "success"),
+					planmock.NewPlanStep("step-4", "pending"),
+				),
+			},
+		},
 		Elasticsearch: []planmock.GeneratedResourceConfig{
 			{
 				ID: "cde7b6b605424a54ce9d56316eab13a1",
@@ -126,6 +137,18 @@ func TestTrackChange(t *testing.T) {
 			},
 		},
 		Appsearch: []planmock.GeneratedResourceConfig{
+			{
+				ID: "6de9b2b605424a54ce9d56316eab13a6",
+				PendingLog: planmock.NewPlanStepLog(
+					planmock.NewPlanStep("step-1", "success"),
+					planmock.NewPlanStep("step-2", "success"),
+					planmock.NewPlanStep("step-3", "success"),
+					planmock.NewPlanStep("step-4", "success"),
+					planmock.NewPlanStep("step-5", "pending"),
+				),
+			},
+		},
+		EnterpriseSearch: []planmock.GeneratedResourceConfig{
 			{
 				ID: "6de9b2b605424a54ce9d56316eab13a6",
 				PendingLog: planmock.NewPlanStepLog(
@@ -255,6 +278,19 @@ func TestTrackChange(t *testing.T) {
 				),
 			},
 		},
+		EnterpriseSearch: []planmock.GeneratedResourceConfig{
+			{
+				ID: "6de9b2b605424a54ce9d56316eab13a6",
+				CurrentLog: planmock.NewPlanStepLog(
+					planmock.NewPlanStep("step-1", "success"),
+					planmock.NewPlanStep("step-2", "success"),
+					planmock.NewPlanStep("step-3", "success"),
+					planmock.NewPlanStep("step-4", "success"),
+					planmock.NewPlanStep("step-5", "success"),
+					planmock.NewPlanStep(planCompleted, "success"),
+				),
+			},
+		},
 		Elasticsearch: []planmock.GeneratedResourceConfig{
 			{
 				ID: "cde7b6b605424a54ce9d56316eab13a1",
@@ -298,6 +334,19 @@ func TestTrackChange(t *testing.T) {
 			},
 		},
 		Appsearch: []planmock.GeneratedResourceConfig{
+			{
+				ID: "6de9b2b605424a54ce9d56316eab13a6",
+				CurrentLog: planmock.NewPlanStepLog(
+					planmock.NewPlanStep("step-1", "success"),
+					planmock.NewPlanStep("step-2", "success"),
+					planmock.NewPlanStep("step-3", "success"),
+					planmock.NewPlanStep("step-4", "success"),
+					planmock.NewPlanStep("step-5", "success"),
+					planmock.NewPlanStep(planCompleted, "success"),
+				),
+			},
+		},
+		EnterpriseSearch: []planmock.GeneratedResourceConfig{
 			{
 				ID: "6de9b2b605424a54ce9d56316eab13a6",
 				CurrentLog: planmock.NewPlanStepLog(
@@ -490,14 +539,17 @@ func TestTrackChange(t *testing.T) {
 				{ID: "4de9b2b605424a54ce9d56316eab13a8", Kind: "kibana", Step: "step-4", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-kibana"},
 				{ID: "5de9b2b605424a54ce9d56316eab13a5", Kind: "apm", Step: "step-4", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-apm"},
 				{ID: "6de9b2b605424a54ce9d56316eab13a6", Kind: "appsearch", Step: "step-4", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-appsearch"},
+				{ID: "6de9b2b605424a54ce9d56316eab13a6", Kind: "enterprise_search", Step: "step-4", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-enterprise_search"},
 				{ID: "cde7b6b605424a54ce9d56316eab13a1", Kind: "elasticsearch", Step: "step-5", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-elasticsearch"},
 				{ID: "4de9b2b605424a54ce9d56316eab13a8", Kind: "kibana", Step: "step-5", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-kibana"},
 				{ID: "5de9b2b605424a54ce9d56316eab13a5", Kind: "apm", Step: "step-5", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-apm"},
 				{ID: "6de9b2b605424a54ce9d56316eab13a6", Kind: "appsearch", Step: "step-5", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-appsearch"},
+				{ID: "6de9b2b605424a54ce9d56316eab13a6", Kind: "enterprise_search", Step: "step-5", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-enterprise_search"},
 				{ID: "cde7b6b605424a54ce9d56316eab13a1", Kind: "elasticsearch", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-elasticsearch", Step: "plan-completed", Finished: true, Err: ErrPlanFinished},
 				{ID: "4de9b2b605424a54ce9d56316eab13a8", Kind: "kibana", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-kibana", Step: "plan-completed", Finished: true, Err: ErrPlanFinished},
 				{ID: "5de9b2b605424a54ce9d56316eab13a5", Kind: "apm", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-apm", Step: "plan-completed", Finished: true, Err: ErrPlanFinished},
 				{ID: "6de9b2b605424a54ce9d56316eab13a6", Kind: "appsearch", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-appsearch", Step: "plan-completed", Finished: true, Err: ErrPlanFinished},
+				{ID: "6de9b2b605424a54ce9d56316eab13a6", Kind: "enterprise_search", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-enterprise_search", Step: "plan-completed", Finished: true, Err: ErrPlanFinished},
 			},
 		},
 		{
@@ -545,14 +597,17 @@ func TestTrackChange(t *testing.T) {
 				{ID: "4de9b2b605424a54ce9d56316eab13a8", Kind: "kibana", Step: "step-4", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-kibana"},
 				{ID: "5de9b2b605424a54ce9d56316eab13a5", Kind: "apm", Step: "step-4", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-apm"},
 				{ID: "6de9b2b605424a54ce9d56316eab13a6", Kind: "appsearch", Step: "step-4", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-appsearch"},
+				{ID: "6de9b2b605424a54ce9d56316eab13a6", Kind: "enterprise_search", Step: "step-4", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-enterprise_search"},
 				{ID: "cde7b6b605424a54ce9d56316eab13a1", Kind: "elasticsearch", Step: "step-5", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-elasticsearch"},
 				{ID: "4de9b2b605424a54ce9d56316eab13a8", Kind: "kibana", Step: "step-5", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-kibana"},
 				{ID: "5de9b2b605424a54ce9d56316eab13a5", Kind: "apm", Step: "step-5", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-apm"},
 				{ID: "6de9b2b605424a54ce9d56316eab13a6", Kind: "appsearch", Step: "step-5", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-appsearch"},
+				{ID: "6de9b2b605424a54ce9d56316eab13a6", Kind: "enterprise_search", Step: "step-5", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-enterprise_search"},
 				{ID: "cde7b6b605424a54ce9d56316eab13a1", Kind: "elasticsearch", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-elasticsearch", Step: "plan-completed", Finished: true, Err: ErrPlanFinished},
 				{ID: "4de9b2b605424a54ce9d56316eab13a8", Kind: "kibana", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-kibana", Step: "plan-completed", Finished: true, Err: ErrPlanFinished},
 				{ID: "5de9b2b605424a54ce9d56316eab13a5", Kind: "apm", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-apm", Step: "plan-completed", Finished: true, Err: ErrPlanFinished},
 				{ID: "6de9b2b605424a54ce9d56316eab13a6", Kind: "appsearch", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-appsearch", Step: "plan-completed", Finished: true, Err: ErrPlanFinished},
+				{ID: "6de9b2b605424a54ce9d56316eab13a6", Kind: "enterprise_search", DeploymentID: "cbb4bc6c09684c86aa5de54c05ea1d38", RefID: "main-enterprise_search", Step: "plan-completed", Finished: true, Err: ErrPlanFinished},
 			},
 		},
 		{

--- a/pkg/plan/track_response.go
+++ b/pkg/plan/track_response.go
@@ -57,7 +57,7 @@ func (res TrackResponse) Error() error {
 }
 
 func (res TrackResponse) String() string {
-	kind := strings.Title(res.Kind)
+	kind := strings.Title(strings.Replace(res.Kind, "_", " ", 1))
 
 	if msg := formatFinishedStep(res, kind); msg != "" {
 		return msg

--- a/pkg/plan/track_response_builder.go
+++ b/pkg/plan/track_response_builder.go
@@ -26,6 +26,7 @@ import (
 	"github.com/go-openapi/strfmt"
 
 	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util"
 )
 
 const (
@@ -53,7 +54,7 @@ var (
 func buildTrackResponse(res *models.DeploymentResources, getCurrentPlan bool) []TrackResponse {
 	var pending = make([]TrackResponse, 0)
 	for _, info := range res.Elasticsearch {
-		p, err := parseResourceInfo(info, "elasticsearch", getCurrentPlan)
+		p, err := parseResourceInfo(info, util.Elasticsearch, getCurrentPlan)
 		if err != nil {
 			continue
 		}
@@ -61,7 +62,7 @@ func buildTrackResponse(res *models.DeploymentResources, getCurrentPlan bool) []
 	}
 
 	for _, info := range res.Kibana {
-		p, err := parseResourceInfo(info, "kibana", getCurrentPlan)
+		p, err := parseResourceInfo(info, util.Kibana, getCurrentPlan)
 		if err != nil {
 			continue
 		}
@@ -69,7 +70,7 @@ func buildTrackResponse(res *models.DeploymentResources, getCurrentPlan bool) []
 	}
 
 	for _, info := range res.Apm {
-		p, err := parseResourceInfo(info, "apm", getCurrentPlan)
+		p, err := parseResourceInfo(info, util.Apm, getCurrentPlan)
 		if err != nil {
 			continue
 		}
@@ -77,7 +78,15 @@ func buildTrackResponse(res *models.DeploymentResources, getCurrentPlan bool) []
 	}
 
 	for _, info := range res.Appsearch {
-		p, err := parseResourceInfo(info, "appsearch", getCurrentPlan)
+		p, err := parseResourceInfo(info, util.Appsearch, getCurrentPlan)
+		if err != nil {
+			continue
+		}
+		pending = append(pending, p)
+	}
+
+	for _, info := range res.EnterpriseSearch {
+		p, err := parseResourceInfo(info, util.EnterpriseSearch, getCurrentPlan)
 		if err != nil {
 			continue
 		}

--- a/pkg/util/kinds.go
+++ b/pkg/util/kinds.go
@@ -27,6 +27,9 @@ const (
 	// Elasticsearch kind
 	Elasticsearch = "elasticsearch"
 
+	// EnterpriseSearch kind
+	EnterpriseSearch = "enterprise_search"
+
 	// Kibana kind
 	Kibana = "kibana"
 )


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->

Adds support for the `enterprise_search` kind to be vacated on allocator
vacates and adds support for the deployment plan change tracker too.

It doesn't refactor any of existing code and just builds on top of it.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #132 
