### PR TITLE
api: Add mock.RoundTripper to transport workflow

### DIFF
--- a/pkg/api/http_transport.go
+++ b/pkg/api/http_transport.go
@@ -24,6 +24,8 @@ import (
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 )
 
 const transportCastErrFmt = "http transport warning: failed converting %T to *http.Transport\n"
@@ -89,6 +91,8 @@ func NewTransport(rt http.RoundTripper, cfg TransportConfig) http.RoundTripper {
 		return NewUserAgentTransport(t, cfg.UserAgent)
 	case *UserAgentTransport:
 		return t
+	case *mock.RoundTripper:
+		return NewUserAgentTransport(t, cfg.UserAgent)
 	default:
 		if cfg.ErrorDevice != nil {
 			fmt.Fprintf(cfg.ErrorDevice, transportCastErrFmt, rt)

--- a/pkg/api/http_transport_test.go
+++ b/pkg/api/http_transport_test.go
@@ -21,6 +21,8 @@ import (
 	"bytes"
 	"net/http"
 	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 )
 
 type mockRT struct{}
@@ -64,6 +66,13 @@ func TestNewTransport(t *testing.T) {
 					SkipTLSVerify:   true,
 				},
 				rt: new(DebugTransport),
+			},
+		},
+		{
+			name: "mock.RoundTripper is returned",
+			args: args{
+				buf: new(bytes.Buffer),
+				rt:  new(mock.RoundTripper),
 			},
 		},
 		{


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Adds another entry to `api.NewTransport` which handles mock.RoundTripper
and returns it wrapped in a UserAgent RoundTripper.

It's meant to improve testing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When testing the `ecctl/pkg/cmd` layer, it'll always print `http transport warning: failed converting *mock.RoundTripper to *http.Transport` unless this patch is merged.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
via `ecctl`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
