### PR TITLE
configurationtemplateapi: Add Format field

### DIFF
--- a/pkg/api/deploymentapi/depresourceapi/apm.go
+++ b/pkg/api/deploymentapi/depresourceapi/apm.go
@@ -51,6 +51,7 @@ func NewApm(params NewStateless) (*models.ApmPayload, error) {
 		API:                params.API,
 		ID:                 params.TemplateID,
 		Region:             params.Region,
+		Format:             "cluster",
 		ShowInstanceConfig: true,
 	})
 	if err != nil {

--- a/pkg/api/deploymentapi/depresourceapi/appsearch.go
+++ b/pkg/api/deploymentapi/depresourceapi/appsearch.go
@@ -51,6 +51,7 @@ func NewAppSearch(params NewStateless) (*models.AppSearchPayload, error) {
 		API:                params.API,
 		ID:                 params.TemplateID,
 		Region:             params.Region,
+		Format:             "cluster",
 		ShowInstanceConfig: true,
 	})
 	if err != nil {

--- a/pkg/api/deploymentapi/depresourceapi/elasticsearch.go
+++ b/pkg/api/deploymentapi/depresourceapi/elasticsearch.go
@@ -124,6 +124,7 @@ func NewElasticsearch(params NewElasticsearchParams) (*models.ElasticsearchPaylo
 		API:                params.API,
 		ID:                 params.TemplateID,
 		Region:             params.Region,
+		Format:             "cluster",
 		ShowInstanceConfig: true,
 	})
 	if err != nil {

--- a/pkg/api/deploymentapi/depresourceapi/kibana.go
+++ b/pkg/api/deploymentapi/depresourceapi/kibana.go
@@ -51,6 +51,7 @@ func NewKibana(params NewStateless) (*models.KibanaPayload, error) {
 		API:                params.API,
 		ID:                 params.TemplateID,
 		Region:             params.Region,
+		Format:             "cluster",
 		ShowInstanceConfig: true,
 	})
 	if err != nil {

--- a/pkg/api/platformapi/configurationtemplateapi/delete_test.go
+++ b/pkg/api/platformapi/configurationtemplateapi/delete_test.go
@@ -73,7 +73,7 @@ func TestDeleteTemplate(t *testing.T) {
 			name: "Platform deployment template delete fails with an empty params",
 			err: multierror.NewPrefixed("invalid deployment template delete params",
 				apierror.ErrMissingAPI,
-				errors.New("invalid template ID"),
+				errors.New("template ID not specified and is required for this operation"),
 				errors.New("region not specified and is required for this operation"),
 			),
 		},

--- a/pkg/api/platformapi/configurationtemplateapi/get.go
+++ b/pkg/api/platformapi/configurationtemplateapi/get.go
@@ -53,7 +53,7 @@ type GetTemplateParams struct {
 }
 
 // Validate is the implementation for the ecctl.Validator interface
-func (params GetTemplateParams) Validate() error {
+func (params *GetTemplateParams) Validate() error {
 	var merr = multierror.NewPrefixed("invalid deployment template get params")
 	if params.API == nil {
 		merr = merr.Append(apierror.ErrMissingAPI)

--- a/pkg/api/platformapi/configurationtemplateapi/get.go
+++ b/pkg/api/platformapi/configurationtemplateapi/get.go
@@ -30,6 +30,8 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 )
 
+const defaultTemplateFormat = "cluster"
+
 var (
 	errInvalidTemplateID     = errors.New("template ID not specified and is required for this operation")
 	errInvalidTemplateFormat = errors.New("template format not specified and is required for this operation")
@@ -72,8 +74,16 @@ func (params GetTemplateParams) Validate() error {
 	return merr.ErrorOrNil()
 }
 
+func (params *GetTemplateParams) fillDefaults() {
+	if strings.TrimSpace(params.Format) == "" {
+		params.Format = defaultTemplateFormat
+	}
+}
+
 // GetTemplate obtains information about a specific platform deployment template
 func GetTemplate(params GetTemplateParams) (*models.DeploymentTemplateInfo, error) {
+	params.fillDefaults()
+
 	if err := params.Validate(); err != nil {
 		return nil, err
 	}

--- a/pkg/api/platformapi/configurationtemplateapi/get_test.go
+++ b/pkg/api/platformapi/configurationtemplateapi/get_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
@@ -41,7 +40,7 @@ var (
 func TestGetTemplate(t *testing.T) {
 	var sourceDate = testutils.ParseDate(t, "2018-04-19T18:16:57.297Z")
 
-	var templateGetSuccess = `
+	var templateFormatCluster = `
 	{
   "name": "(Trial) Default Elasticsearch",
   "source": {
@@ -78,6 +77,29 @@ func TestGetTemplate(t *testing.T) {
 	},
 	"system_owned": false
 }`
+
+	var templateFormatDeployment = `
+	{
+  "name": "(Trial) Default Elasticsearch",
+  "source": {
+	"user_id": "1",
+	"facilitator": "adminconsole",
+	"date": "2018-04-19T18:16:57.297Z",
+	"admin_id": "admin",
+	"action": "deployments.create-template",
+	"remote_addresses": ["52.205.1.231"]
+  },
+  "description": "Test default Elasticsearch trial template",
+  "id": "` + validTemplateID + `",
+  "metadata": [{
+	"key": "trial",
+	"value": "true"
+	}],
+	"deployment_template": {
+        "resources": {}
+    },
+	"system_owned": false
+}`
 	tests := []struct {
 		name string
 		args GetTemplateParams
@@ -87,10 +109,11 @@ func TestGetTemplate(t *testing.T) {
 		{
 			name: "Platform deployment template show succeeds",
 			args: GetTemplateParams{
-				ID: validTemplateID,
+				ID:     validTemplateID,
+				Format: "cluster",
 				API: api.NewMock(mock.Response{
 					Response: http.Response{
-						Body:       mock.NewStringBody(templateGetSuccess),
+						Body:       mock.NewStringBody(templateFormatCluster),
 						StatusCode: 200,
 					},
 					Assert: &mock.RequestAssertion{
@@ -146,23 +169,71 @@ func TestGetTemplate(t *testing.T) {
 			},
 		},
 		{
+			name: "Platform deployment template show with format deployment succeeds",
+			args: GetTemplateParams{
+				ID:     validTemplateID,
+				Format: "deployment",
+				API: api.NewMock(mock.Response{
+					Response: http.Response{
+						Body:       mock.NewStringBody(templateFormatDeployment),
+						StatusCode: 200,
+					},
+					Assert: &mock.RequestAssertion{
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Host:   api.DefaultMockHost,
+						Query: url.Values{
+							"format":                       {"deployment"},
+							"show_instance_configurations": {"false"},
+						},
+						Path: "/api/v1/regions/us-east-1/platform/configuration/templates/deployments/84e0bd6d69bb44e294809d89cea88a7e",
+					},
+				}),
+				Region: "us-east-1",
+			},
+			want: &models.DeploymentTemplateInfo{
+				Name:        ec.String("(Trial) Default Elasticsearch"),
+				ID:          validTemplateID,
+				Description: "Test default Elasticsearch trial template",
+				SystemOwned: ec.Bool(false),
+				Metadata: []*models.MetadataItem{{
+
+					Value: ec.String("true"),
+					Key:   ec.String("trial"),
+				}},
+				Source: &models.ChangeSourceInfo{
+					UserID:          "1",
+					Facilitator:     ec.String("adminconsole"),
+					Date:            &sourceDate,
+					AdminID:         "admin",
+					Action:          ec.String("deployments.create-template"),
+					RemoteAddresses: []string{"52.205.1.231"},
+				},
+				DeploymentTemplate: &models.DeploymentCreateRequest{
+					Resources: &models.DeploymentCreateResources{},
+				},
+			},
+		},
+		{
 			name: "Platform deployment template show fails due to API error",
 			args: GetTemplateParams{
 				ID:     validTemplateID,
+				Format: "deployment",
 				Region: "us-east-1",
 				API:    api.NewMock(mock.Response{Error: errors.New("error")}),
 			},
 			err: &url.Error{
 				Op:  "Get",
-				URL: `https://mock.elastic.co/api/v1/regions/us-east-1/platform/configuration/templates/deployments/84e0bd6d69bb44e294809d89cea88a7e?format=cluster&show_instance_configurations=false`,
+				URL: `https://mock.elastic.co/api/v1/regions/us-east-1/platform/configuration/templates/deployments/84e0bd6d69bb44e294809d89cea88a7e?format=deployment&show_instance_configurations=false`,
 				Err: errors.New("error"),
 			},
 		},
 		{
 			name: "Platform deployment template show fails due to parameter validation",
 			err: multierror.NewPrefixed("invalid deployment template get params",
-				apierror.ErrMissingAPI,
-				errors.New("invalid template ID"),
+				errors.New("api reference is required for the operation"),
+				errors.New("template ID not specified and is required for this operation"),
+				errors.New("template format not specified and is required for this operation"),
 				errors.New("region not specified and is required for this operation"),
 			),
 		},

--- a/pkg/api/platformapi/configurationtemplateapi/get_test.go
+++ b/pkg/api/platformapi/configurationtemplateapi/get_test.go
@@ -233,7 +233,6 @@ func TestGetTemplate(t *testing.T) {
 			err: multierror.NewPrefixed("invalid deployment template get params",
 				errors.New("api reference is required for the operation"),
 				errors.New("template ID not specified and is required for this operation"),
-				errors.New("template format not specified and is required for this operation"),
 				errors.New("region not specified and is required for this operation"),
 			),
 		},

--- a/pkg/api/platformapi/configurationtemplateapi/list.go
+++ b/pkg/api/platformapi/configurationtemplateapi/list.go
@@ -19,6 +19,7 @@ package configurationtemplateapi
 
 import (
 	"context"
+	"strings"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
@@ -43,6 +44,10 @@ type ListTemplateParams struct {
 	// An optional key/value pair in the form of (key:value) that will act as a filter and exclude any templates
 	// that do not have a matching metadata item associated.
 	Metadata string
+
+	// If cluster is specified populates cluster_template in the response,
+	// if deployment is specified populates deployment_template in the response
+	Format string
 }
 
 // Validate is the implementation for the ecctl.Validator interface
@@ -50,6 +55,10 @@ func (params ListTemplateParams) Validate() error {
 	var merr = multierror.NewPrefixed("invalid deployment template list params")
 	if params.API == nil {
 		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	if strings.TrimSpace(params.Format) == "" {
+		merr = merr.Append(errInvalidTemplateFormat)
 	}
 
 	if err := ec.RequireRegionSet(params.Region); err != nil {
@@ -70,6 +79,7 @@ func ListTemplates(params ListTemplateParams) ([]*models.DeploymentTemplateInfo,
 			WithContext(api.WithRegion(context.Background(), params.Region)).
 			WithStackVersion(ec.String(params.StackVersion)).
 			WithMetadata(ec.String(params.Metadata)).
+			WithFormat(ec.String(params.Format)).
 			WithShowInstanceConfigurations(ec.Bool(params.ShowInstanceConfig)),
 		params.AuthWriter,
 	)

--- a/pkg/api/platformapi/configurationtemplateapi/list.go
+++ b/pkg/api/platformapi/configurationtemplateapi/list.go
@@ -51,7 +51,7 @@ type ListTemplateParams struct {
 }
 
 // Validate is the implementation for the ecctl.Validator interface
-func (params ListTemplateParams) Validate() error {
+func (params *ListTemplateParams) Validate() error {
 	var merr = multierror.NewPrefixed("invalid deployment template list params")
 	if params.API == nil {
 		merr = merr.Append(apierror.ErrMissingAPI)

--- a/pkg/api/platformapi/configurationtemplateapi/list.go
+++ b/pkg/api/platformapi/configurationtemplateapi/list.go
@@ -68,8 +68,16 @@ func (params ListTemplateParams) Validate() error {
 	return merr.ErrorOrNil()
 }
 
+func (params *ListTemplateParams) fillDefaults() {
+	if strings.TrimSpace(params.Format) == "" {
+		params.Format = defaultTemplateFormat
+	}
+}
+
 // ListTemplates obtains all the configured platform deployment templates
 func ListTemplates(params ListTemplateParams) ([]*models.DeploymentTemplateInfo, error) {
+	params.fillDefaults()
+
 	if err := params.Validate(); err != nil {
 		return nil, err
 	}

--- a/pkg/api/platformapi/configurationtemplateapi/list_test.go
+++ b/pkg/api/platformapi/configurationtemplateapi/list_test.go
@@ -147,7 +147,6 @@ func TestListTemplates(t *testing.T) {
 			name: "Platform deployment templates fails with empty params",
 			err: multierror.NewPrefixed("invalid deployment template list params",
 				errors.New("api reference is required for the operation"),
-				errors.New("template format not specified and is required for this operation"),
 				errors.New("region not specified and is required for this operation"),
 			),
 		},

--- a/pkg/api/platformapi/configurationtemplateapi/pull.go
+++ b/pkg/api/platformapi/configurationtemplateapi/pull.go
@@ -37,6 +37,7 @@ type PullToFolderParams struct {
 	*api.API
 	Folder             string
 	Region             string
+	Format             string
 	ShowInstanceConfig bool
 }
 
@@ -68,6 +69,7 @@ func PullToFolder(params PullToFolderParams) error {
 		API:                params.API,
 		Region:             params.Region,
 		ShowInstanceConfig: params.ShowInstanceConfig,
+		Format:             params.Format,
 	})
 	if err != nil {
 		return err

--- a/pkg/api/platformapi/configurationtemplateapi/pull.go
+++ b/pkg/api/platformapi/configurationtemplateapi/pull.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
@@ -51,10 +50,6 @@ func (params PullToFolderParams) Validate() error {
 
 	if params.Folder == "" {
 		merr = merr.Append(errors.New(folderErrorMessage))
-	}
-
-	if strings.TrimSpace(params.Format) == "" {
-		merr = merr.Append(errInvalidTemplateFormat)
 	}
 
 	if err := ec.RequireRegionSet(params.Region); err != nil {

--- a/pkg/api/platformapi/configurationtemplateapi/pull.go
+++ b/pkg/api/platformapi/configurationtemplateapi/pull.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
@@ -50,6 +51,10 @@ func (params PullToFolderParams) Validate() error {
 
 	if params.Folder == "" {
 		merr = merr.Append(errors.New(folderErrorMessage))
+	}
+
+	if strings.TrimSpace(params.Format) == "" {
+		merr = merr.Append(errInvalidTemplateFormat)
 	}
 
 	if err := ec.RequireRegionSet(params.Region); err != nil {

--- a/pkg/api/platformapi/configurationtemplateapi/pull_test.go
+++ b/pkg/api/platformapi/configurationtemplateapi/pull_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
-	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
@@ -63,8 +62,9 @@ func TestPullToFolder(t *testing.T) {
 		{
 			name: "fails due to param validation",
 			err: multierror.NewPrefixed("invalid deployment template pull params",
-				apierror.ErrMissingAPI,
+				errors.New("api reference is required for the operation"),
 				errors.New("folder not specified and is required for the operation"),
+				errors.New("template format not specified and is required for this operation"),
 				errors.New("region not specified and is required for this operation"),
 			),
 		},

--- a/pkg/api/platformapi/configurationtemplateapi/pull_test.go
+++ b/pkg/api/platformapi/configurationtemplateapi/pull_test.go
@@ -64,7 +64,6 @@ func TestPullToFolder(t *testing.T) {
 			err: multierror.NewPrefixed("invalid deployment template pull params",
 				errors.New("api reference is required for the operation"),
 				errors.New("folder not specified and is required for the operation"),
-				errors.New("template format not specified and is required for this operation"),
 				errors.New("region not specified and is required for this operation"),
 			),
 		},

--- a/pkg/api/platformapi/configurationtemplateapi/pull_test.go
+++ b/pkg/api/platformapi/configurationtemplateapi/pull_test.go
@@ -73,6 +73,7 @@ func TestPullToFolder(t *testing.T) {
 			args: args{params: PullToFolderParams{
 				Region: "us-east-1",
 				Folder: "some",
+				Format: "cluster",
 				API:    api.NewMock(mock.Response{Error: errors.New("error")}),
 			}},
 			err: &url.Error{
@@ -86,6 +87,7 @@ func TestPullToFolder(t *testing.T) {
 			args: args{params: PullToFolderParams{
 				Region: "us-east-1",
 				Folder: "some",
+				Format: "cluster",
 				API:    api.NewMock(mock.Response{Error: errors.New("error")}),
 			}},
 			err: &url.Error{
@@ -99,6 +101,7 @@ func TestPullToFolder(t *testing.T) {
 			args: args{params: PullToFolderParams{
 				Region: "us-east-1",
 				Folder: "some-folder",
+				Format: "cluster",
 				API: api.NewMock(mock.Response{
 					Response: http.Response{
 						Body:       mock.NewStructBody(templateListSuccess),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This patch adds a new required `Format` field to the `GetTemplateParams`, `ListTemplatesParams` and `PullToFolderParams` structs.

This will allow the use of the `WithFormat()` method, in order to specify which inofrmation is populated in the response.
If "cluster" is specified, cluster_template is pupulated in the response. If deployment is specified, deployment_template is populated in the response.

## Related Issues
Closes: https://github.com/elastic/cloud-sdk-go/issues/159

## Motivation and Context
Preparation for using the new deployment template endpoint which uses the `deployment` format

## How Has This Been Tested?
Unit tests, and manually by testing with ecctl

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
