### PR TITLE
deploymentapi: Support List and filter templates

### DIFF
--- a/pkg/api/deploymentapi/depresourceapi/apm_test.go
+++ b/pkg/api/deploymentapi/depresourceapi/apm_test.go
@@ -113,6 +113,7 @@ func TestNewApm(t *testing.T) {
 				errors.New("deployment template info is not specified and is required for the operation"),
 				apierror.ErrDeploymentID,
 				errors.New("topology: region cannot be empty"),
+				errors.New("required version not provided"),
 			),
 		},
 		{
@@ -122,6 +123,7 @@ func TestNewApm(t *testing.T) {
 				API:                      api.NewMock(mock.SampleInternalError()),
 				Region:                   "ece-region",
 				DeploymentTemplateInfoV2: &models.DeploymentTemplateInfoV2{Name: ec.String("default")},
+				Version:                  "7.8.0",
 			}},
 			err: mock.MultierrorInternalError,
 		},
@@ -129,6 +131,7 @@ func TestNewApm(t *testing.T) {
 			name: "obtains the deployment info but fails getting the template ID info",
 			args: args{params: NewStateless{
 				DeploymentID: mock.ValidClusterID,
+				Version:      "7.8.0",
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
 						Resources: &models.DeploymentResources{
@@ -148,10 +151,9 @@ func TestNewApm(t *testing.T) {
 		{
 			name: "obtains the deployment info but fails getting the template ID info from the API",
 			args: args{params: NewStateless{
-				DeploymentID: mock.ValidClusterID,
-				API: api.NewMock(
-					mock.SampleInternalError(),
-				),
+				DeploymentID:             mock.ValidClusterID,
+				Version:                  "7.8.0",
+				API:                      api.NewMock(mock.SampleInternalError()),
 				Region:                   "ece-region",
 				DeploymentTemplateInfoV2: &models.DeploymentTemplateInfoV2{Name: ec.String("default")},
 			}},
@@ -161,6 +163,7 @@ func TestNewApm(t *testing.T) {
 			name: "obtains the deployment template when no template ID is defined but it's an invalid template for apm",
 			args: args{params: NewStateless{
 				DeploymentID: mock.ValidClusterID,
+				Version:      "7.8.0",
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(getResponse)),
 					mock.New200Response(mock.NewStructBody(crossClusterTemplateResponse)),
@@ -174,6 +177,7 @@ func TestNewApm(t *testing.T) {
 			name: "succeeds with no argument override",
 			args: args{params: NewStateless{
 				DeploymentID: mock.ValidClusterID,
+				Version:      "7.8.0",
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(apmTemplateResponse)),
 				),
@@ -187,7 +191,7 @@ func TestNewApm(t *testing.T) {
 				Region:                    ec.String("ece-region"),
 				RefID:                     ec.String("main-apm"),
 				Plan: &models.ApmPlan{
-					Apm: &models.ApmConfiguration{},
+					Apm: &models.ApmConfiguration{Version: "7.8.0"},
 					ClusterTopology: []*models.ApmTopologyElement{
 						{
 							Size: &models.TopologySize{
@@ -206,6 +210,7 @@ func TestNewApm(t *testing.T) {
 				Size:         4096,
 				ZoneCount:    3,
 				DeploymentID: mock.ValidClusterID,
+				Version:      "7.8.0",
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(getResponse)),
 					mock.New200Response(mock.NewStructBody(apmTemplateResponse)),
@@ -218,7 +223,7 @@ func TestNewApm(t *testing.T) {
 				Region:                    ec.String("ece-region"),
 				RefID:                     ec.String("main-apm"),
 				Plan: &models.ApmPlan{
-					Apm: &models.ApmConfiguration{},
+					Apm: &models.ApmConfiguration{Version: "7.8.0"},
 					ClusterTopology: []*models.ApmTopologyElement{
 						{
 							Size: &models.TopologySize{

--- a/pkg/api/deploymentapi/depresourceapi/appsearch_test.go
+++ b/pkg/api/deploymentapi/depresourceapi/appsearch_test.go
@@ -113,6 +113,7 @@ func TestNewAppSearch(t *testing.T) {
 				errors.New("deployment template info is not specified and is required for the operation"),
 				apierror.ErrDeploymentID,
 				errors.New("topology: region cannot be empty"),
+				errors.New("required version not provided"),
 			),
 		},
 		{
@@ -121,6 +122,7 @@ func TestNewAppSearch(t *testing.T) {
 				DeploymentID:             mock.ValidClusterID,
 				API:                      api.NewMock(mock.SampleInternalError()),
 				Region:                   "ece-region",
+				Version:                  "7.8.0",
 				DeploymentTemplateInfoV2: &models.DeploymentTemplateInfoV2{Name: ec.String("default")},
 			}},
 			err: mock.MultierrorInternalError,
@@ -129,6 +131,7 @@ func TestNewAppSearch(t *testing.T) {
 			name: "obtains the deployment info but fails getting the template ID info",
 			args: args{params: NewStateless{
 				DeploymentID: mock.ValidClusterID,
+				Version:      "7.8.0",
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
 						Resources: &models.DeploymentResources{
@@ -149,6 +152,7 @@ func TestNewAppSearch(t *testing.T) {
 			name: "obtains the deployment info but fails getting the template ID info from the API",
 			args: args{params: NewStateless{
 				DeploymentID: mock.ValidClusterID,
+				Version:      "7.8.0",
 				API: api.NewMock(
 					mock.SampleInternalError(),
 				),
@@ -161,6 +165,7 @@ func TestNewAppSearch(t *testing.T) {
 			name: "obtains the deployment template but it's an invalid template for appsearch",
 			args: args{params: NewStateless{
 				DeploymentID: mock.ValidClusterID,
+				Version:      "7.8.0",
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(getResponse)),
 					mock.New200Response(mock.NewStructBody(defaultTemplateResponse)),
@@ -173,6 +178,7 @@ func TestNewAppSearch(t *testing.T) {
 		{
 			name: "succeeds with no argument override",
 			args: args{params: NewStateless{
+				Version:      "7.8.0",
 				DeploymentID: mock.ValidClusterID,
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(appsearchTemplateResponse)),
@@ -187,7 +193,7 @@ func TestNewAppSearch(t *testing.T) {
 				Region:                    ec.String("ece-region"),
 				RefID:                     ec.String("main-appsearch"),
 				Plan: &models.AppSearchPlan{
-					Appsearch: &models.AppSearchConfiguration{},
+					Appsearch: &models.AppSearchConfiguration{Version: "7.8.0"},
 					ClusterTopology: []*models.AppSearchTopologyElement{
 						{
 							Size: &models.TopologySize{
@@ -205,6 +211,7 @@ func TestNewAppSearch(t *testing.T) {
 			args: args{params: NewStateless{
 				Size:         4096,
 				ZoneCount:    3,
+				Version:      "7.8.0",
 				DeploymentID: mock.ValidClusterID,
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(getResponse)),
@@ -218,7 +225,7 @@ func TestNewAppSearch(t *testing.T) {
 				Region:                    ec.String("ece-region"),
 				RefID:                     ec.String("main-appsearch"),
 				Plan: &models.AppSearchPlan{
-					Appsearch: &models.AppSearchConfiguration{},
+					Appsearch: &models.AppSearchConfiguration{Version: "7.8.0"},
 					ClusterTopology: []*models.AppSearchTopologyElement{
 						{
 							Size: &models.TopologySize{

--- a/pkg/api/deploymentapi/depresourceapi/elasticsearch_parser_test.go
+++ b/pkg/api/deploymentapi/depresourceapi/elasticsearch_parser_test.go
@@ -115,72 +115,16 @@ func TestParseElasticsearchInput(t *testing.T) {
 			},
 		},
 		{
-			name: "returns the payload from a set of raw topology elements and auto-discovers version",
-			args: args{params: ParseElasticsearchInputParams{
-				API: api.NewMock(
-					mock.New200Response(mock.NewStructBody(models.StackVersionConfigs{
-						Stacks: []*models.StackVersionConfig{
-							{Version: "6.4.2"},
-							{Version: "7.4.2"},
-							{Version: "5.4.2"},
-						},
-					})),
-					mock.New200Response(mock.NewStructBody(elasticsearchTemplateResponse)),
-				),
-				NewElasticsearchParams: NewElasticsearchParams{
-					Region:                   "ece-region",
-					Name:                     "mycluster",
-					DeploymentTemplateInfoV2: &elasticsearchTemplateResponse,
-				},
-				TopologyElements: rawClusterTopology,
-			}},
-			want: &models.ElasticsearchPayload{
-				DisplayName: "mycluster",
-				Region:      ec.String("ece-region"),
-				RefID:       ec.String(DefaultElasticsearchRefID),
-				Plan: &models.ElasticsearchClusterPlan{
-					Elasticsearch: &models.ElasticsearchConfiguration{
-						Version: "7.4.2",
-					},
-					DeploymentTemplate: &models.DeploymentTemplateReference{
-						ID: ec.String(DefaultTemplateID),
-					},
-					ClusterTopology: clusterTopology,
-				},
-			},
-		},
-		{
-			name: "returns the payload from a set of raw topology elements and fails the version auto-discover",
-			args: args{params: ParseElasticsearchInputParams{
-				API: api.NewMock(
-					mock.New200Response(mock.NewStringBody("failed to get the version error")),
-				),
-				NewElasticsearchParams: NewElasticsearchParams{
-					Region:                   "ece-region",
-					Name:                     "mycluster",
-					DeploymentTemplateInfoV2: &elasticsearchTemplateResponse,
-				},
-				TopologyElements: rawClusterTopology,
-			}},
-			err: errors.New("version discovery: failed to obtain stack list, please specify a version"),
-		},
-		{
 			name: "returns the payload from size and zonecount elements and auto-discovers version",
 			args: args{params: ParseElasticsearchInputParams{
 				API: api.NewMock(
-					mock.New200Response(mock.NewStructBody(models.StackVersionConfigs{
-						Stacks: []*models.StackVersionConfig{
-							{Version: "6.4.2"},
-							{Version: "7.4.2"},
-							{Version: "5.4.2"},
-						},
-					})),
 					mock.New200Response(mock.NewStructBody(elasticsearchTemplateResponse)),
 				),
 				NewElasticsearchParams: NewElasticsearchParams{
 					Region:                   "ece-region",
 					Name:                     "mycluster",
 					DeploymentTemplateInfoV2: &elasticsearchTemplateResponse,
+					Version:                  "7.8.0",
 				},
 				Size:      2048,
 				ZoneCount: 3,
@@ -191,7 +135,7 @@ func TestParseElasticsearchInput(t *testing.T) {
 				RefID:       ec.String(DefaultElasticsearchRefID),
 				Plan: &models.ElasticsearchClusterPlan{
 					Elasticsearch: &models.ElasticsearchConfiguration{
-						Version: "7.4.2",
+						Version: "7.8.0",
 					},
 					DeploymentTemplate: &models.DeploymentTemplateReference{
 						ID: ec.String(DefaultTemplateID),
@@ -213,13 +157,14 @@ func TestParseElasticsearchInput(t *testing.T) {
 			},
 		},
 		{
-			name: "returns the payload from size and zonecount elements and auto-discovers version",
+			name: "returns the payload from size and zonecount elements ",
 			args: args{params: ParseElasticsearchInputParams{
 				API: api.NewMock(),
 				NewElasticsearchParams: NewElasticsearchParams{
 					Region:                   "ece-region",
 					Name:                     "mycluster",
 					DeploymentTemplateInfoV2: &elasticsearchTemplateResponse,
+					Version:                  "7.8.0",
 				},
 				TopologyElements: []string{
 					`{"name": ""}`,

--- a/pkg/api/deploymentapi/depresourceapi/enterprise_search_test.go
+++ b/pkg/api/deploymentapi/depresourceapi/enterprise_search_test.go
@@ -113,6 +113,7 @@ func TestNewEnterpriseSearch(t *testing.T) {
 				errors.New("deployment template info is not specified and is required for the operation"),
 				apierror.ErrDeploymentID,
 				errors.New("topology: region cannot be empty"),
+				errors.New("required version not provided"),
 			),
 		},
 		{
@@ -121,6 +122,7 @@ func TestNewEnterpriseSearch(t *testing.T) {
 				DeploymentID:             mock.ValidClusterID,
 				API:                      api.NewMock(mock.SampleInternalError()),
 				Region:                   "ece-region",
+				Version:                  "7.8.0",
 				DeploymentTemplateInfoV2: &models.DeploymentTemplateInfoV2{Name: ec.String("default")},
 			}},
 			err: mock.MultierrorInternalError,
@@ -128,6 +130,7 @@ func TestNewEnterpriseSearch(t *testing.T) {
 		{
 			name: "obtains the deployment info but fails getting the template ID info",
 			args: args{params: NewStateless{
+				Version:      "7.8.0",
 				DeploymentID: mock.ValidClusterID,
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
@@ -148,6 +151,7 @@ func TestNewEnterpriseSearch(t *testing.T) {
 		{
 			name: "obtains the deployment info but fails getting the template ID info from the API",
 			args: args{params: NewStateless{
+				Version:      "7.8.0",
 				DeploymentID: mock.ValidClusterID,
 				API: api.NewMock(
 					mock.SampleInternalError(),
@@ -160,6 +164,7 @@ func TestNewEnterpriseSearch(t *testing.T) {
 		{
 			name: "obtains the deployment template but it's an invalid template for enterprise search",
 			args: args{params: NewStateless{
+				Version:      "7.8.0",
 				DeploymentID: mock.ValidClusterID,
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(getResponse)),
@@ -174,6 +179,7 @@ func TestNewEnterpriseSearch(t *testing.T) {
 			name: "succeeds with no argument override",
 			args: args{params: NewStateless{
 				DeploymentID: mock.ValidClusterID,
+				Version:      "7.8.0",
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(enterpriseSearchTemplateResponse)),
 				),
@@ -187,7 +193,7 @@ func TestNewEnterpriseSearch(t *testing.T) {
 				Region:                    ec.String("ece-region"),
 				RefID:                     ec.String("main-enterprise_search"),
 				Plan: &models.EnterpriseSearchPlan{
-					EnterpriseSearch: &models.EnterpriseSearchConfiguration{},
+					EnterpriseSearch: &models.EnterpriseSearchConfiguration{Version: "7.8.0"},
 					ClusterTopology: []*models.EnterpriseSearchTopologyElement{
 						{
 							Size: &models.TopologySize{
@@ -203,6 +209,7 @@ func TestNewEnterpriseSearch(t *testing.T) {
 		{
 			name: "succeeds with argument overrides",
 			args: args{params: NewStateless{
+				Version:      "7.8.0",
 				Size:         4096,
 				ZoneCount:    3,
 				DeploymentID: mock.ValidClusterID,
@@ -218,7 +225,7 @@ func TestNewEnterpriseSearch(t *testing.T) {
 				Region:                    ec.String("ece-region"),
 				RefID:                     ec.String("main-enterprise_search"),
 				Plan: &models.EnterpriseSearchPlan{
-					EnterpriseSearch: &models.EnterpriseSearchConfiguration{},
+					EnterpriseSearch: &models.EnterpriseSearchConfiguration{Version: "7.8.0"},
 					ClusterTopology: []*models.EnterpriseSearchTopologyElement{
 						{
 							Size: &models.TopologySize{

--- a/pkg/api/deploymentapi/depresourceapi/kibana_test.go
+++ b/pkg/api/deploymentapi/depresourceapi/kibana_test.go
@@ -113,6 +113,7 @@ func TestNewKibana(t *testing.T) {
 				errors.New("deployment template info is not specified and is required for the operation"),
 				apierror.ErrDeploymentID,
 				errors.New("topology: region cannot be empty"),
+				errors.New("required version not provided"),
 			),
 		},
 		{
@@ -121,6 +122,7 @@ func TestNewKibana(t *testing.T) {
 				DeploymentID:             mock.ValidClusterID,
 				API:                      api.NewMock(mock.SampleInternalError()),
 				Region:                   "ece-region",
+				Version:                  "7.8.0",
 				DeploymentTemplateInfoV2: &models.DeploymentTemplateInfoV2{Name: ec.String("default")},
 			}},
 			err: mock.MultierrorInternalError,
@@ -129,6 +131,7 @@ func TestNewKibana(t *testing.T) {
 			name: "obtains the deployment info but fails getting the template ID info",
 			args: args{params: NewStateless{
 				DeploymentID: mock.ValidClusterID,
+				Version:      "7.8.0",
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(models.DeploymentGetResponse{
 						Resources: &models.DeploymentResources{
@@ -149,6 +152,7 @@ func TestNewKibana(t *testing.T) {
 			name: "obtains the deployment info but fails getting the template ID info",
 			args: args{params: NewStateless{
 				DeploymentID: mock.ValidClusterID,
+				Version:      "7.8.0",
 				API: api.NewMock(
 					mock.SampleInternalError(),
 				),
@@ -161,6 +165,7 @@ func TestNewKibana(t *testing.T) {
 			name: "obtains the deployment template when no template ID is defined but it's an invalid template for kibana",
 			args: args{params: NewStateless{
 				DeploymentID: mock.ValidClusterID,
+				Version:      "7.8.0",
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(getResponse)),
 					mock.New200Response(mock.NewStructBody(invalidTemplateResponse)),
@@ -174,6 +179,7 @@ func TestNewKibana(t *testing.T) {
 			name: "succeeds with no argument override",
 			args: args{params: NewStateless{
 				DeploymentID: mock.ValidClusterID,
+				Version:      "7.8.0",
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(kibanaTemplateResponse)),
 				),
@@ -187,7 +193,7 @@ func TestNewKibana(t *testing.T) {
 				Region:                    ec.String("ece-region"),
 				RefID:                     ec.String("main-kibana"),
 				Plan: &models.KibanaClusterPlan{
-					Kibana: &models.KibanaConfiguration{},
+					Kibana: &models.KibanaConfiguration{Version: "7.8.0"},
 					ClusterTopology: []*models.KibanaClusterTopologyElement{
 						{
 							Size: &models.TopologySize{
@@ -203,6 +209,7 @@ func TestNewKibana(t *testing.T) {
 		{
 			name: "succeeds with argument overrides",
 			args: args{params: NewStateless{
+				Version:      "7.8.0",
 				Size:         4096,
 				ZoneCount:    3,
 				DeploymentID: mock.ValidClusterID,
@@ -218,7 +225,7 @@ func TestNewKibana(t *testing.T) {
 				Region:                    ec.String("ece-region"),
 				RefID:                     ec.String("main-kibana"),
 				Plan: &models.KibanaClusterPlan{
-					Kibana: &models.KibanaConfiguration{},
+					Kibana: &models.KibanaConfiguration{Version: "7.8.0"},
 					ClusterTopology: []*models.KibanaClusterTopologyElement{
 						{
 							Size: &models.TopologySize{

--- a/pkg/api/deploymentapi/depresourceapi/new_payload.go
+++ b/pkg/api/deploymentapi/depresourceapi/new_payload.go
@@ -57,6 +57,7 @@ type NewPayloadParams struct {
 }
 
 // NewPayload creates the payload for a deployment
+// // * Auto-discovers the latest Stack version if Version is not specified.
 func NewPayload(params NewPayloadParams) (*models.DeploymentCreateRequest, error) {
 	res, err := deptemplateapi.Get(deptemplateapi.GetParams{
 		API:        params.API,
@@ -68,10 +69,21 @@ func NewPayload(params NewPayloadParams) (*models.DeploymentCreateRequest, error
 		return nil, err
 	}
 
+	// Version Discovery
+	version, err := LatestStackVersion(LatestStackVersionParams{
+		Writer:  params.Writer,
+		API:     params.API,
+		Version: params.Version,
+		Region:  params.Region,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	esPayload, err := ParseElasticsearchInput(ParseElasticsearchInputParams{
 		NewElasticsearchParams: NewElasticsearchParams{
 			RefID:                    params.ElasticsearchInstance.RefID,
-			Version:                  params.Version,
+			Version:                  version,
 			Plugins:                  params.Plugins,
 			Region:                   params.Region,
 			TemplateID:               params.DeploymentTemplateID,
@@ -91,7 +103,7 @@ func NewPayload(params NewPayloadParams) (*models.DeploymentCreateRequest, error
 		ElasticsearchRefID:       params.ElasticsearchInstance.RefID,
 		API:                      params.API,
 		RefID:                    params.KibanaInstance.RefID,
-		Version:                  params.Version,
+		Version:                  version,
 		Region:                   params.Region,
 		TemplateID:               params.DeploymentTemplateID,
 		Size:                     params.KibanaInstance.Size,
@@ -112,7 +124,7 @@ func NewPayload(params NewPayloadParams) (*models.DeploymentCreateRequest, error
 			ElasticsearchRefID:       params.ElasticsearchInstance.RefID,
 			API:                      params.API,
 			RefID:                    params.ApmInstance.RefID,
-			Version:                  params.Version,
+			Version:                  version,
 			Region:                   params.Region,
 			TemplateID:               params.DeploymentTemplateID,
 			Size:                     params.ApmInstance.Size,
@@ -131,7 +143,7 @@ func NewPayload(params NewPayloadParams) (*models.DeploymentCreateRequest, error
 			ElasticsearchRefID:       params.ElasticsearchInstance.RefID,
 			API:                      params.API,
 			RefID:                    params.AppsearchInstance.RefID,
-			Version:                  params.Version,
+			Version:                  version,
 			Region:                   params.Region,
 			TemplateID:               params.DeploymentTemplateID,
 			Size:                     params.AppsearchInstance.Size,
@@ -151,7 +163,7 @@ func NewPayload(params NewPayloadParams) (*models.DeploymentCreateRequest, error
 				ElasticsearchRefID:       params.ElasticsearchInstance.RefID,
 				API:                      params.API,
 				RefID:                    params.EnterpriseSearchInstance.RefID,
-				Version:                  params.Version,
+				Version:                  version,
 				Region:                   params.Region,
 				TemplateID:               params.DeploymentTemplateID,
 				Size:                     params.EnterpriseSearchInstance.Size,

--- a/pkg/api/deploymentapi/depresourceapi/new_payload.go
+++ b/pkg/api/deploymentapi/depresourceapi/new_payload.go
@@ -51,6 +51,9 @@ type NewPayloadParams struct {
 	ApmInstance              InstanceParams
 	AppsearchInstance        InstanceParams
 	EnterpriseSearchInstance InstanceParams
+
+	// Do not use. The field will be removed once an API bug has been resolved.
+	DeploymentTemplateAsList bool
 }
 
 // NewPayload creates the payload for a deployment
@@ -59,6 +62,7 @@ func NewPayload(params NewPayloadParams) (*models.DeploymentCreateRequest, error
 		API:        params.API,
 		TemplateID: params.DeploymentTemplateID,
 		Region:     params.Region,
+		AsList:     params.DeploymentTemplateAsList,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/api/deploymentapi/depresourceapi/new_payload.go
+++ b/pkg/api/deploymentapi/depresourceapi/new_payload.go
@@ -36,13 +36,15 @@ type InstanceParams struct {
 type NewPayloadParams struct {
 	*api.API
 
-	Name                     string
-	Version                  string
-	DeploymentTemplateID     string
-	Region                   string
-	ApmEnable                bool
-	AppsearchEnable          bool
-	EnterpriseSearchEnable   bool
+	Name                   string
+	Version                string
+	DeploymentTemplateID   string
+	Region                 string
+	ApmEnable              bool
+	AppsearchEnable        bool
+	EnterpriseSearchEnable bool
+	// Do not use. The field will be removed once an API bug has been resolved.
+	DeploymentTemplateAsList bool
 	Writer                   io.Writer
 	Plugins                  []string
 	TopologyElements         []string
@@ -51,9 +53,6 @@ type NewPayloadParams struct {
 	ApmInstance              InstanceParams
 	AppsearchInstance        InstanceParams
 	EnterpriseSearchInstance InstanceParams
-
-	// Do not use. The field will be removed once an API bug has been resolved.
-	DeploymentTemplateAsList bool
 }
 
 // NewPayload creates the payload for a deployment

--- a/pkg/api/deploymentapi/depresourceapi/new_payload_test.go
+++ b/pkg/api/deploymentapi/depresourceapi/new_payload_test.go
@@ -340,6 +340,72 @@ func TestNewPayload(t *testing.T) {
 			}},
 		},
 		{
+			name: "Succeeds to create a deployment payload with ES and Kibana instances (AsList)",
+			args: args{params: NewPayloadParams{
+				Version:                  "7.6.1",
+				Region:                   "ece-region",
+				DeploymentTemplateAsList: true,
+				ElasticsearchInstance: InstanceParams{
+					RefID:     "main-elasticsearch",
+					Size:      1024,
+					ZoneCount: 1,
+				},
+				KibanaInstance: InstanceParams{
+					RefID:     "main-kibana",
+					Size:      1024,
+					ZoneCount: 1,
+				},
+				DeploymentTemplateID: "default",
+				API: api.NewMock(
+					mock.New200Response(mock.NewStructBody([]models.DeploymentTemplateInfoV2{kibanaTemplateResponse})),
+				),
+			}},
+			want: &models.DeploymentCreateRequest{Resources: &models.DeploymentCreateResources{
+				Elasticsearch: []*models.ElasticsearchPayload{{
+					RefID:  ec.String("main-elasticsearch"),
+					Region: ec.String("ece-region"),
+					Plan: &models.ElasticsearchClusterPlan{
+						Elasticsearch: &models.ElasticsearchConfiguration{
+							Version: "7.6.1",
+						},
+						DeploymentTemplate: &models.DeploymentTemplateReference{
+							ID: ec.String("default"),
+						},
+						ClusterTopology: []*models.ElasticsearchClusterTopologyElement{{
+							ZoneCount:               1,
+							InstanceConfigurationID: "default.data",
+							Size: &models.TopologySize{
+								Resource: ec.String("memory"),
+								Value:    ec.Int32(1024),
+							},
+							NodeType: &models.ElasticsearchNodeType{
+								Data: ec.Bool(true),
+							},
+						}},
+					}},
+				},
+				Kibana: []*models.KibanaPayload{{
+					ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+					Region:                    ec.String("ece-region"),
+					RefID:                     ec.String("main-kibana"),
+					Plan: &models.KibanaClusterPlan{
+						Kibana: &models.KibanaConfiguration{
+							Version: "7.6.1",
+						},
+						ClusterTopology: []*models.KibanaClusterTopologyElement{
+							{
+								Size: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+								ZoneCount: 1,
+							},
+						},
+					},
+				}},
+			}},
+		},
+		{
 			name: "Succeeds to create a deployment payload with ES, Kibana and APM instances",
 			args: args{params: NewPayloadParams{
 				Version: "7.6.1",
@@ -363,6 +429,97 @@ func TestNewPayload(t *testing.T) {
 				ApmEnable:            true,
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(apmKibanaTemplateResponse)),
+				),
+			}},
+			want: &models.DeploymentCreateRequest{Resources: &models.DeploymentCreateResources{
+				Elasticsearch: []*models.ElasticsearchPayload{{
+					RefID:  ec.String("main-elasticsearch"),
+					Region: ec.String("ece-region"),
+					Plan: &models.ElasticsearchClusterPlan{
+						Elasticsearch: &models.ElasticsearchConfiguration{
+							Version: "7.6.1",
+						},
+						DeploymentTemplate: &models.DeploymentTemplateReference{
+							ID: ec.String("default"),
+						},
+						ClusterTopology: []*models.ElasticsearchClusterTopologyElement{{
+							ZoneCount:               1,
+							InstanceConfigurationID: "default.data",
+							Size: &models.TopologySize{
+								Resource: ec.String("memory"),
+								Value:    ec.Int32(1024),
+							},
+							NodeType: &models.ElasticsearchNodeType{
+								Data: ec.Bool(true),
+							},
+						}},
+					}},
+				},
+				Kibana: []*models.KibanaPayload{{
+					ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+					Region:                    ec.String("ece-region"),
+					RefID:                     ec.String("main-kibana"),
+					Plan: &models.KibanaClusterPlan{
+						Kibana: &models.KibanaConfiguration{
+							Version: "7.6.1",
+						},
+						ClusterTopology: []*models.KibanaClusterTopologyElement{
+							{
+								Size: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+								ZoneCount: 1,
+							},
+						},
+					},
+				}},
+				Apm: []*models.ApmPayload{{
+					ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+					Region:                    ec.String("ece-region"),
+					RefID:                     ec.String("main-apm"),
+					Plan: &models.ApmPlan{
+						Apm: &models.ApmConfiguration{
+							Version: "7.6.1",
+						},
+						ClusterTopology: []*models.ApmTopologyElement{
+							{
+								Size: &models.TopologySize{
+									Resource: ec.String("memory"),
+									Value:    ec.Int32(1024),
+								},
+								ZoneCount: 1,
+							},
+						},
+					},
+				}},
+			}},
+		},
+		{
+			name: "Succeeds to create a deployment payload with ES, Kibana and APM instances (AsList)",
+			args: args{params: NewPayloadParams{
+				Version:                  "7.6.1",
+				Region:                   "ece-region",
+				DeploymentTemplateAsList: true,
+				ElasticsearchInstance: InstanceParams{
+					RefID:     "main-elasticsearch",
+					Size:      1024,
+					ZoneCount: 1,
+				},
+				KibanaInstance: InstanceParams{
+					RefID:     "main-kibana",
+					Size:      1024,
+					ZoneCount: 1,
+				},
+				ApmInstance: InstanceParams{
+					RefID:     "main-apm",
+					Size:      1024,
+					ZoneCount: 1,
+				},
+				DeploymentTemplateID: "default",
+				ApmEnable:            true,
+				API: api.NewMock(
+					mock.New200Response(mock.NewStructBody([]models.DeploymentTemplateInfoV2{apmKibanaTemplateResponse})),
 				),
 			}},
 			want: &models.DeploymentCreateRequest{Resources: &models.DeploymentCreateResources{

--- a/pkg/api/deploymentapi/depresourceapi/new_stateless.go
+++ b/pkg/api/deploymentapi/depresourceapi/new_stateless.go
@@ -81,6 +81,10 @@ func (params *NewStateless) Validate() error {
 		merr = merr.Append(errors.New("topology: region cannot be empty"))
 	}
 
+	if params.Version == "" {
+		merr = merr.Append(errors.New("required version not provided"))
+	}
+
 	return merr.ErrorOrNil()
 }
 

--- a/pkg/api/deploymentapi/deptemplateapi/get_test.go
+++ b/pkg/api/deploymentapi/deptemplateapi/get_test.go
@@ -42,6 +42,17 @@ func TestGet(t *testing.T) {
 	if err := json.Unmarshal(getRawResp, &succeedResp); err != nil {
 		t.Fatal(err)
 	}
+
+	listRawResp, err := ioutil.ReadFile("./testdata/list.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var listSucceedResp []*models.DeploymentTemplateInfoV2
+	if err := json.Unmarshal(listRawResp, &listSucceedResp); err != nil {
+		t.Fatal(err)
+	}
+
 	type args struct {
 		params GetParams
 	}
@@ -104,6 +115,54 @@ func TestGet(t *testing.T) {
 			want: succeedResp,
 		},
 		{
+			name: "succeeds when AsList is set to true",
+			args: args{params: GetParams{
+				Region:     "us-east-1",
+				TemplateID: "default",
+				AsList:     true,
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/templates",
+						Query: url.Values{
+							"region":                       []string{"us-east-1"},
+							"show_hidden":                  []string{"false"},
+							"show_instance_configurations": []string{"true"},
+						},
+					},
+					mock.NewByteBody(listRawResp),
+				)),
+			}},
+			want: succeedResp,
+		},
+		{
+			name: "fails when AsList is set to true and deployment template cannot be found",
+			args: args{params: GetParams{
+				Region:     "us-east-1",
+				TemplateID: "some-other-template",
+				AsList:     true,
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/templates",
+						Query: url.Values{
+							"region":                       []string{"us-east-1"},
+							"show_hidden":                  []string{"false"},
+							"show_instance_configurations": []string{"true"},
+						},
+					},
+					mock.NewByteBody(listRawResp),
+				)),
+			}},
+			err: multierror.NewPrefixed("failed obtaining deployment template",
+				errors.New(`deployment template "some-other-template" cannot be found`),
+			),
+		},
+		{
 			name: "fails on API error",
 			args: args{params: GetParams{
 				Region:     "us-east-1",
@@ -116,6 +175,29 @@ func TestGet(t *testing.T) {
 						Path:   "/api/v1/deployments/templates/some-id",
 						Query: url.Values{
 							"region":                       []string{"us-east-1"},
+							"show_instance_configurations": []string{"true"},
+						},
+					},
+					mock.SampleInternalError().Response.Body,
+				)),
+			}},
+			err: mock.MultierrorInternalError,
+		},
+		{
+			name: "returns error when List returns error",
+			args: args{params: GetParams{
+				Region:     "us-east-1",
+				TemplateID: "some-id",
+				AsList:     true,
+				API: api.NewMock(mock.New500ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/templates",
+						Query: url.Values{
+							"region":                       []string{"us-east-1"},
+							"show_hidden":                  []string{"false"},
 							"show_instance_configurations": []string{"true"},
 						},
 					},


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
Adds a workaround for a missing API so that the deployment templates can
be obtained on ESS by using the `deploymenttemplateapi.List()` method
with a filter function that returns an error when the template is not
found.

The behavior is controlled with a boolean `AsList` in `GetParams` and
a bool named `DeploymentTemplateAsList` on the `NewPayloadParams`.

This boolean should be removed as soon as the GET endpoint for a single
deployment template is available on ESS.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
elastic/ecctl#335

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
unit tested thoroughly and manually tested in `ecctl`.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) (Although strictly not a bug...)
