### PR TITLE
depresourceapi: Change the 'Name' field in ElasticsearchTopologyElement for 'NodeType'

### DIFF
--- a/pkg/api/deploymentapi/depresourceapi/elasticsearch_parser_test.go
+++ b/pkg/api/deploymentapi/depresourceapi/elasticsearch_parser_test.go
@@ -32,9 +32,9 @@ import (
 
 func TestParseElasticsearchInput(t *testing.T) {
 	var rawClusterTopology = []string{
-		`{"name": "data", "size": 2048, "zone_count": 2}`,
-		`{"name": "ml", "size": 4096, "zone_count": 1}`,
-		`{"name": "master", "size": 1024, "zone_count": 1}`,
+		`{"node_type": "data", "size": 2048, "zone_count": 2}`,
+		`{"node_type": "ml", "size": 4096, "zone_count": 1}`,
+		`{"node_type": "master", "size": 1024, "zone_count": 1}`,
 	}
 	var clusterTopology = []*models.ElasticsearchClusterTopologyElement{
 		{
@@ -167,11 +167,11 @@ func TestParseElasticsearchInput(t *testing.T) {
 					Version:                  "7.8.0",
 				},
 				TopologyElements: []string{
-					`{"name": ""}`,
+					`{"node_type": ""}`,
 				},
 			}},
 			err: multierror.NewPrefixed("elasticsearch topology",
-				errors.New("name cannot be empty"),
+				errors.New("node_type cannot be empty"),
 				errors.New("size cannot be empty"),
 			),
 		},

--- a/pkg/api/deploymentapi/depresourceapi/elasticsearch_test.go
+++ b/pkg/api/deploymentapi/depresourceapi/elasticsearch_test.go
@@ -97,7 +97,7 @@ func TestNewElasticsearch(t *testing.T) {
 				errors.New("deployment template info is not specified and is required for the operation"),
 				errors.New("region cannot be empty"),
 				errors.New("version cannot be empty"),
-				errors.New("element[0]: elasticsearch topology: name cannot be empty"),
+				errors.New("element[0]: elasticsearch topology: node_type cannot be empty"),
 				errors.New("element[0]: elasticsearch topology: size cannot be empty"),
 			),
 		},
@@ -109,10 +109,10 @@ func TestNewElasticsearch(t *testing.T) {
 				TemplateID:               "default",
 				DeploymentTemplateInfoV2: &elasticsearchTemplateResponse,
 				Topology: []ElasticsearchTopologyElement{
-					{Name: "some", Size: 1024},
+					{NodeType: "some", Size: 1024},
 				},
 			}},
-			err: errors.New(`deployment topology: failed to obtain desired topology names ([{Name:some ZoneCount:0 Size:1024}]) in deployment template id "default"`),
+			err: errors.New(`deployment topology: failed to obtain desired topology names ([{NodeType:some ZoneCount:0 Size:1024}]) in deployment template id "default"`),
 		},
 		{
 			name: "fails due to unknown invalid template",
@@ -127,7 +127,7 @@ func TestNewElasticsearch(t *testing.T) {
 					},
 				},
 				Topology: []ElasticsearchTopologyElement{
-					{Name: "some", Size: 1024},
+					{NodeType: "some", Size: 1024},
 				},
 			}},
 			err: errors.New("deployment: the default template is not configured for Elasticsearch. Please use another template if you wish to start Elasticsearch instances"),
@@ -175,9 +175,9 @@ func TestNewElasticsearch(t *testing.T) {
 				TemplateID:               "default",
 				DeploymentTemplateInfoV2: &elasticsearchTemplateResponse,
 				Topology: []ElasticsearchTopologyElement{
-					{Name: DataNode, Size: 8192, ZoneCount: 2},
-					{Name: MasterNode, Size: 1024, ZoneCount: 1},
-					{Name: MLNode, Size: 2048, ZoneCount: 1},
+					{NodeType: DataNode, Size: 8192, ZoneCount: 2},
+					{NodeType: MasterNode, Size: 1024, ZoneCount: 1},
+					{NodeType: MLNode, Size: 2048, ZoneCount: 1},
 				},
 			}},
 			want: &models.ElasticsearchPayload{

--- a/pkg/api/deploymentapi/depresourceapi/elasticsearch_topology.go
+++ b/pkg/api/deploymentapi/depresourceapi/elasticsearch_topology.go
@@ -46,7 +46,7 @@ var (
 
 	// DefaultTopologyElement defines the element used in DefaultTopology
 	DefaultTopologyElement = ElasticsearchTopologyElement{
-		Name:      DataNode,
+		NodeType:  DataNode,
 		Size:      DefaultDataSize,
 		ZoneCount: DefaultDataZoneCount,
 	}
@@ -67,8 +67,8 @@ type BuildElasticsearchTopologyParams struct {
 // ElasticsearchTopologyElement is a single cluster topology element, meaning
 // a number of instances (controlled by ZoneCount) for a single NodeType.
 type ElasticsearchTopologyElement struct {
-	// Name can be one of "data", "master" or "ml".
-	Name string `json:"name"`
+	// NodeType can be one of "data", "master" or "ml".
+	NodeType string `json:"node_type"`
 
 	// Number of zones to span the cluster on.
 	ZoneCount int32 `json:"zone_count,omitempty"`
@@ -87,8 +87,8 @@ func (element *ElasticsearchTopologyElement) fillDefaults() {
 // Validate ensures the parameters are usable by the consuming function.
 func (element *ElasticsearchTopologyElement) Validate() error {
 	var merr = multierror.NewPrefixed("elasticsearch topology")
-	if element.Name == "" {
-		merr = merr.Append(errors.New("name cannot be empty"))
+	if element.NodeType == "" {
+		merr = merr.Append(errors.New("node_type cannot be empty"))
 	}
 
 	if element.Size == 0 {
@@ -173,19 +173,19 @@ func BuildElasticsearchTopology(params BuildElasticsearchTopologyParams) ([]*mod
 
 // matchNodeType compares  ElasticsearchTopologyElement name (NodeType) to the
 // actual NodeTypes specified in a deployment template cluster topology. The
-// Name field can be ["data", "master", "ml"].
+// NodeType field can be ["data", "master", "ml"].
 func matchNodeType(got models.ElasticsearchNodeType, want ElasticsearchTopologyElement) bool {
-	if want.Name == DataNode {
+	if want.NodeType == DataNode {
 		return got.Data != nil && *got.Data
 	}
 
-	if want.Name == MasterNode {
+	if want.NodeType == MasterNode {
 		var dataFalse = (got.Data != nil && !*got.Data) || got.Data == nil
 		var masterTrue = got.Master != nil && *got.Master
 		return dataFalse && masterTrue
 	}
 
-	if want.Name == MLNode {
+	if want.NodeType == MLNode {
 		var dataFalse = (got.Data != nil && !*got.Data) || got.Data == nil
 		var mlTrue = got.Ml != nil && *got.Ml
 		return dataFalse && mlTrue

--- a/pkg/api/deploymentapi/depresourceapi/elasticsearch_topology_test.go
+++ b/pkg/api/deploymentapi/depresourceapi/elasticsearch_topology_test.go
@@ -42,30 +42,30 @@ func TestNewElasticsearchTopology(t *testing.T) {
 		{
 			name: "correctly parses a single element topology",
 			args: args{topology: []string{
-				`{"name": "data", "size": 1024, "zone_count": 1}`,
+				`{"node_type": "data", "size": 1024, "zone_count": 1}`,
 			}},
 			want: []ElasticsearchTopologyElement{
-				{Name: "data", Size: 1024, ZoneCount: 1},
+				{NodeType: "data", Size: 1024, ZoneCount: 1},
 			},
 		},
 		{
 			name: "correctly parses a multi element topology",
 			args: args{topology: []string{
-				`{"name": "data", "size": 2048, "zone_count": 2}`,
-				`{"name": "ml", "size": 4096, "zone_count": 1}`,
-				`{"name": "master", "size": 1024, "zone_count": 1}`,
+				`{"node_type": "data", "size": 2048, "zone_count": 2}`,
+				`{"node_type": "ml", "size": 4096, "zone_count": 1}`,
+				`{"node_type": "master", "size": 1024, "zone_count": 1}`,
 			}},
 			want: []ElasticsearchTopologyElement{
-				{Name: "data", Size: 2048, ZoneCount: 2},
-				{Name: "ml", Size: 4096, ZoneCount: 1},
-				{Name: "master", Size: 1024, ZoneCount: 1},
+				{NodeType: "data", Size: 2048, ZoneCount: 2},
+				{NodeType: "ml", Size: 4096, ZoneCount: 1},
+				{NodeType: "master", Size: 1024, ZoneCount: 1},
 			},
 		},
 		{
 			name: "fails due to invalid json parses a multi element topology",
 			args: args{topology: []string{
-				`{"name": "data", "size": 2048, "zone_count": 2}`,
-				`{"name": "ml", "size": 4096, "zone_count": 1}`,
+				`{"node_type": "data", "size": 2048, "zone_count": 2}`,
+				`{"node_type": "ml", "size": 4096, "zone_count": 1}`,
 				`{"aaaaaaaaaa`,
 			}},
 			err: errors.New("depresourceapi: failed unpacking raw topology: unexpected end of JSON input"),
@@ -76,7 +76,7 @@ func TestNewElasticsearchTopology(t *testing.T) {
 				`{"zone_count": 2}`,
 			}},
 			err: multierror.NewPrefixed("elasticsearch topology",
-				errors.New("name cannot be empty"),
+				errors.New("node_type cannot be empty"),
 				errors.New("size cannot be empty"),
 			),
 		},
@@ -114,7 +114,7 @@ func TestNewElasticsearchTopologyElement(t *testing.T) {
 			name: "returns a parametrized ElasticsearchTopologyElement",
 			args: args{size: 2048, zoneCount: 3},
 			want: ElasticsearchTopologyElement{
-				Name:      DataNode,
+				NodeType:  DataNode,
 				Size:      2048,
 				ZoneCount: 3,
 			},
@@ -180,20 +180,20 @@ func TestBuildElasticsearchTopology(t *testing.T) {
 			args: args{params: BuildElasticsearchTopologyParams{
 				TemplateID: "sometemplateid",
 				Topology: []ElasticsearchTopologyElement{
-					{Name: "something weird", Size: 2048, ZoneCount: 1},
+					{NodeType: "something weird", Size: 2048, ZoneCount: 1},
 				},
 				ClusterTopology: topologies,
 			}},
-			err: errors.New(`deployment topology: failed to obtain desired topology names ([{Name:something weird ZoneCount:1 Size:2048}]) in deployment template id "sometemplateid"`),
+			err: errors.New(`deployment topology: failed to obtain desired topology names ([{NodeType:something weird ZoneCount:1 Size:2048}]) in deployment template id "sometemplateid"`),
 		},
 		{
 			name: "matches the topologies",
 			args: args{params: BuildElasticsearchTopologyParams{
 				TemplateID: "sometemplateid",
 				Topology: []ElasticsearchTopologyElement{
-					{Name: DataNode, Size: 8192, ZoneCount: 2},
-					{Name: MasterNode, Size: 1024, ZoneCount: 1},
-					{Name: MLNode, Size: 2048, ZoneCount: 1},
+					{NodeType: DataNode, Size: 8192, ZoneCount: 2},
+					{NodeType: MasterNode, Size: 1024, ZoneCount: 1},
+					{NodeType: MLNode, Size: 2048, ZoneCount: 1},
 				},
 				ClusterTopology: topologies,
 			}},


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the title above. -->

## Description
In order to make things simpler for our users, this patch changes the
'Name' field in ElasticsearchTopologyElement for 'NodeType'

## Related Issues
https://github.com/elastic/ecctl/issues/335

## Motivation and Context
UX

## How Has This Been Tested?
Unit tests and manually by faking the SDK in ecctl

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
