### PR TITLE
deploymentsize: Fixes a bug in ParseGb()

### DIFF
--- a/pkg/api/deploymentapi/deploymentsize/sizes.go
+++ b/pkg/api/deploymentapi/deploymentsize/sizes.go
@@ -29,8 +29,9 @@ const minsize = 512
 // ParseGb converts the stringified gigabyte size notation to an int32 Megabyte
 // notation. The minimum size allowed is 0.5g Megabytes with 0.5g increments.
 func ParseGb(strSize string) (int32, error) {
+	strSize = strings.ToLower(strSize)
 	re := regexp.MustCompile(`(?m)(.*\w)(g)`)
-	matches := re.FindStringSubmatch(strings.ToLower(strSize))
+	matches := re.FindStringSubmatch(strSize)
 	if len(matches) < 2 {
 		fmt.Println(matches, "length", len(matches))
 		return 0, fmt.Errorf(`failed to convert "%s" to <size><g>`, strSize)

--- a/pkg/api/deploymentapi/deploymentsize/sizes_test.go
+++ b/pkg/api/deploymentapi/deploymentsize/sizes_test.go
@@ -43,6 +43,14 @@ func TestParse(t *testing.T) {
 			args: args{strSize: "8gb"}, want: 8 * 1024,
 		},
 		{
+			name: "parses a 0.5G (gigabyte notation)",
+			args: args{strSize: "0.5G"}, want: 512,
+		},
+		{
+			name: "parses a 8GB (gigabyte notation)",
+			args: args{strSize: "8GB"}, want: 8 * 1024,
+		},
+		{
 			name: "trying to parse 512m returns a failure",
 			args: args{strSize: "512m"},
 			err:  errors.New(`failed to convert "512m" to <size><g>`),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes a bug where defining memory size in capital letters failed with 
a misleading error.

For example: If `"4G"` was passed, the error would be
`strconv.ParseFloat: parsing "4g": invalid syntax`.

The function now accepts capitalised letters as well.


## Motivation and Context
bug fix and UX

## How Has This Been Tested?
Manually by faking the SDK in ecctl and unit tests.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
