### PR TITLE
error: Add JSON formatted errors for vacate APIs

### DIFF
--- a/pkg/api/apierror/json.go
+++ b/pkg/api/apierror/json.go
@@ -15,31 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package multierror
+package apierror
 
-import (
-	"errors"
-	"fmt"
-	"io"
-	"os"
-)
-
-var output io.Writer = os.Stdout
-
-func ExamplePrefixed() {
-	err := NewPrefixed("config validation")
-	err = err.Append(errors.New("some validation error"))
-
-	if err.ErrorOrNil() != nil {
-		fmt.Fprintln(output, err)
-	}
+// JSONError wraps any incoming error inside this struct so that it can be
+// correctly  marshaled to JSON. If Error() is called, the error is still
+// returned in a string format.
+type JSONError struct {
+	Message string `json:"message,omitempty"`
 }
 
-func ExamplePrefixed_json() {
-	err := NewPrefixed("config validation")
-	err = err.Append(errors.New("some validation error"))
+// Error complies with the error interface
+func (me JSONError) Error() string { return me.Message }
 
-	if err.ErrorOrNil() != nil {
-		fmt.Fprintln(output, WithFormat(err, "json"))
-	}
+// NewJSONError creates a marshaleable error from an error.
+func NewJSONError(err error) error {
+	return JSONError{Message: err.Error()}
 }

--- a/pkg/api/platformapi/allocatorapi/vacate_error.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_error.go
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package allocatorapi
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+)
+
+const (
+	resourcePrefixErrFmt  = "allocator %s: resource id [%s][%s]: %s"
+	allocatorPrefixErrFmt = "allocator %s: %s"
+)
+
+// VacateError wraps an error and enriches it with some fields to be able to
+// have a consistent output (resourcePrefixErrFmt). Or by being serialized to
+// JSON by using `multierror.WithFormat`.
+type VacateError struct {
+	AllocatorID string `json:"allocator_id,omitempty"`
+	ResourceID  string `json:"resource_id,omitempty"`
+	Kind        string `json:"kind,omitempty"`
+	Ctx         string `json:"context,omitempty"`
+	Err         error  `json:"error,omitempty"`
+}
+
+func (e VacateError) Error() string {
+	var err = e.Err.Error()
+
+	if e.Ctx != "" {
+		err = fmt.Sprintf("%s: %s", e.Ctx, err)
+	}
+
+	if e.Kind == "" {
+		e.Kind = "unknown"
+	}
+
+	if e.AllocatorID != "" && e.ResourceID == "" && e.Kind == "" {
+		return fmt.Sprintf(allocatorPrefixErrFmt, e.AllocatorID, err)
+	}
+
+	return fmt.Sprintf(resourcePrefixErrFmt,
+		e.AllocatorID, e.ResourceID, e.Kind, err,
+	)
+}
+
+// MarshalJSON Implements the json.Marshaler interface to be able to modify the
+// error and format it in JSON.w
+func (e VacateError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		AllocatorID string `json:"allocator_id,omitempty"`
+		ResourceID  string `json:"resource_id,omitempty"`
+		Kind        string `json:"kind,omitempty"`
+		Ctx         string `json:"context,omitempty"`
+		Err         error  `json:"error,omitempty"`
+	}{
+		AllocatorID: e.AllocatorID,
+		ResourceID:  e.ResourceID,
+		Kind:        e.Kind,
+		Ctx:         e.Ctx,
+		Err:         apierror.NewJSONError(e.Err),
+	})
+}

--- a/pkg/api/platformapi/allocatorapi/vacate_responses_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_responses_test.go
@@ -47,6 +47,7 @@ const planStepLogErrorMessage = "Unexpected error during step: [perform-snapshot
 type vacateCase struct {
 	topology     []vacateCaseClusters
 	skipTracking bool
+	outputFormat string
 	region       string
 }
 
@@ -512,6 +513,9 @@ func newAllocator(t *testing.T, id, clusterID, kind string) io.ReadCloser {
 func newVacateTestCase(t *testing.T, tc vacateCase) *VacateParams {
 	var responses = make([]mock.Response, 0, len(tc.topology))
 	var allocators = make([]string, 0, len(tc.topology))
+	if tc.outputFormat == "" {
+		tc.outputFormat = "text"
+	}
 
 	// Do top level Vacate() Calls
 	for i := range tc.topology {
@@ -596,7 +600,7 @@ func newVacateTestCase(t *testing.T, tc vacateCase) *VacateParams {
 		Output:         output.NewDevice(sdkSync.NewBuffer()),
 		Allocators:     allocators,
 		API:            api.NewMock(responses...),
-		OutputFormat:   "text",
+		OutputFormat:   tc.outputFormat,
 		Region:         tc.region,
 		Concurrency:    1,
 		MaxPollRetries: 1,

--- a/pkg/multierror/format.go
+++ b/pkg/multierror/format.go
@@ -1,0 +1,82 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package multierror
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/go-openapi/swag"
+	"github.com/hashicorp/go-multierror"
+)
+
+// JSONError wraps a list of errors to be encodede in JSON format.
+type JSONError struct {
+	Errors []interface{} `json:"errors,omitempty"`
+}
+
+// WithFormatFunc takes in an error and tries to set the ErrorFormatFunc to the
+// passed function if the error is of type *Prefixed or *multierror.Error,
+// otherwise it returns the erorr as is.
+func WithFormatFunc(err error, ff FormatFunc) error {
+	var merr *Prefixed
+	if errors.As(err, &merr) {
+		merr.FormatFunc = ff
+	}
+
+	var hashiErr *multierror.Error
+	if errors.As(err, &hashiErr) {
+		hashiErr.ErrorFormat = multierror.ErrorFormatFunc(ff)
+	}
+
+	return err
+}
+
+// WithFormat is convenient a helper to modify the multierror format function
+// to the JSON format, if the format isn't "json", then the unmodified error is
+// returned.
+func WithFormat(err error, format string) error {
+	if !strings.EqualFold(format, "json") {
+		return err
+	}
+
+	return WithFormatFunc(err, JSONFormatFunc)
+}
+
+// JSONFormatFunc takes in a list of errors and encodes each error to JSON.
+// If the error is not encodable to JSON, then the error is transformed to the
+// json format: `{"message": "err.Error()"}`.
+func JSONFormatFunc(es []error) string {
+	var buf = new(bytes.Buffer)
+	var enc = json.NewEncoder(buf)
+	enc.SetIndent("", "  ")
+	var errs = make([]interface{}, 0, len(es))
+	for _, e := range es {
+		var t = make(map[string]interface{})
+		if err := swag.FromDynamicJSON(e, &t); len(t) == 0 || err != nil {
+			t["message"] = e.Error()
+		}
+		errs = append(errs, t)
+	}
+
+	_ = enc.Encode(JSONError{Errors: errs})
+
+	return buf.String()
+}

--- a/pkg/multierror/format.go
+++ b/pkg/multierror/format.go
@@ -27,14 +27,14 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-// JSONError wraps a list of errors to be encodede in JSON format.
+// JSONError wraps a list of errors to be encoded in JSON format.
 type JSONError struct {
 	Errors []interface{} `json:"errors,omitempty"`
 }
 
 // WithFormatFunc takes in an error and tries to set the ErrorFormatFunc to the
 // passed function if the error is of type *Prefixed or *multierror.Error,
-// otherwise it returns the erorr as is.
+// otherwise it returns the error as is.
 func WithFormatFunc(err error, ff FormatFunc) error {
 	var merr *Prefixed
 	if errors.As(err, &merr) {

--- a/pkg/multierror/format_test.go
+++ b/pkg/multierror/format_test.go
@@ -1,0 +1,163 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package multierror
+
+import (
+	"errors"
+	"io/ioutil"
+	"path"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/client/clusters_elasticsearch"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestWithFormat(t *testing.T) {
+	type args struct {
+		err    error
+		format string
+	}
+	tests := []struct {
+		name string
+		args args
+		err  error
+	}{
+		{
+			name: `non "json" format simply returns the error`,
+			args: args{
+				err:    errors.New("some error"),
+				format: "some format",
+			},
+			err: errors.New("some error"),
+		},
+		{
+			name: `"json" format on not a multierror returns the error`,
+			args: args{
+				err:    errors.New("some error"),
+				format: "json",
+			},
+			err: errors.New("some error"),
+		},
+		{
+			name: `non "json" format simply returns the error`,
+			args: args{
+				err:    NewPrefixed("some prefix"),
+				format: "some format",
+			},
+			err: NewPrefixed("some prefix"),
+		},
+		{
+			name: `"json" format on a multierror returns the error with the format func set`,
+			args: args{
+				err:    &Prefixed{Prefix: "some prefix"},
+				format: "json",
+			},
+			err: &Prefixed{Prefix: "some prefix"},
+		},
+		{
+			name: `"json" format on a multierror returns the error with the format func set`,
+			args: args{
+				err:    new(multierror.Error),
+				format: "json",
+			},
+			err: new(multierror.Error),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := WithFormat(tt.args.err, tt.args.format)
+
+			// Sadly, in Go it's not possible to compare two functions, instead we're relying on the
+			// declared function name to ensure that what we expect has been set, has been.
+			if tt.args.format == "json" {
+				// Prefixed asseertion.
+				var merr *Prefixed
+				if errors.As(err, &merr) {
+					funcName := path.Base(runtime.FuncForPC(reflect.ValueOf(merr.FormatFunc).Pointer()).Name())
+					if funcName != "multierror.JSONFormatFunc" {
+						t.Errorf("WithFormat() error = %s, wantErr multierror.JSONFormatFunc", funcName)
+					}
+				}
+
+				// multierror.Error assertion.
+				var hashiErr *multierror.Error
+				if errors.As(err, &hashiErr) {
+					funcName := path.Base(runtime.FuncForPC(reflect.ValueOf(hashiErr.ErrorFormat).Pointer()).Name())
+					if funcName != "multierror.JSONFormatFunc" {
+						t.Errorf("WithFormat() error = %s, wantErr multierror.JSONFormatFunc", funcName)
+					}
+				}
+			} else if !assert.Equal(t, err, tt.err) {
+				t.Errorf("WithFormat() error = %v, wantErr %v", err, tt.err)
+			}
+		})
+	}
+}
+
+func TestJSONFormatFunc(t *testing.T) {
+	b, err := ioutil.ReadFile("./testdata/multierror.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	type args struct {
+		es []error
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "marshal",
+			args: args{es: []error{
+				errors.New("some"),
+				errors.New("some 2"),
+				errors.New("some 3"),
+				&clusters_elasticsearch.DeleteEsClusterRetryWith{
+					Payload: &models.BasicFailedReply{
+						Errors: []*models.BasicFailedReplyElement{
+							{
+								Code:    ec.String("clusters.cluster_plan_state_error"),
+								Message: ec.String("There are running instances"),
+							},
+							{
+								Code:    ec.String("auth.invalid_password"),
+								Fields:  []string{"body.password"},
+								Message: ec.String("request password doesn't match the user's password"),
+							},
+						},
+					},
+				},
+			}},
+			want: string(b),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := JSONFormatFunc(tt.args.es); got != tt.want {
+				t.Errorf("JSONFormatFunc() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/multierror/prefixed.go
+++ b/pkg/multierror/prefixed.go
@@ -67,10 +67,16 @@ func (p *Prefixed) Error() string {
 	}
 
 	if p.FormatFunc == nil {
-		p.FormatFunc = multierror.ListFormatFunc
+		p.FormatFunc = wrapPrefix(p.Prefix, multierror.ListFormatFunc)
 	}
 
-	return fmt.Sprint(p.Prefix, ": ", p.FormatFunc(p.Errors))
+	return p.FormatFunc(p.Errors)
+}
+
+func wrapPrefix(prefix string, f FormatFunc) FormatFunc {
+	return func(es []error) string {
+		return fmt.Sprint(prefix, ": ", f(es))
+	}
 }
 
 func unpackErrors(prefix string, errs ...error) []error {

--- a/pkg/multierror/prefixed_test.go
+++ b/pkg/multierror/prefixed_test.go
@@ -277,7 +277,7 @@ func TestPrefixed_Error(t *testing.T) {
 					errors.New("some error"),
 				},
 			},
-			want: "prefix: some bogus return",
+			want: "some bogus return",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/multierror/testdata/multierror.json
+++ b/pkg/multierror/testdata/multierror.json
@@ -1,0 +1,32 @@
+{
+  "errors": [
+    {
+      "message": "some"
+    },
+    {
+      "message": "some 2"
+    },
+    {
+      "message": "some 3"
+    },
+    {
+      "Payload": {
+        "errors": [
+          {
+            "code": "clusters.cluster_plan_state_error",
+            "fields": null,
+            "message": "There are running instances"
+          },
+          {
+            "code": "auth.invalid_password",
+            "fields": [
+              "body.password"
+            ],
+            "message": "request password doesn't match the user's password"
+          }
+        ]
+      },
+      "XCloudErrorCodes": ""
+    }
+  ]
+}

--- a/pkg/plan/planutil/track.go
+++ b/pkg/plan/planutil/track.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/elastic/cloud-sdk-go/pkg/plan"
@@ -73,9 +72,5 @@ func TrackChange(params TrackChangeParams) error {
 		return plan.StreamJSON(channel, params.Writer, false)
 	}
 
-	if params.Format == "text" {
-		return plan.Stream(channel, params.Writer)
-	}
-
-	return plan.StreamJSON(channel, ioutil.Discard, false)
+	return plan.Stream(channel, params.Writer)
 }

--- a/pkg/plan/stream_format.go
+++ b/pkg/plan/stream_format.go
@@ -17,19 +17,7 @@
 
 package plan
 
-// Legacy cluster format (DEPRECATED, will be removed in a future version)
-const (
-	// legacyStreamFormat with green color
-	legacyStreamFinishFormat = "\x1b[92;mCluster [%s][%s]: finished running all the plan steps\x1b[0m (Total plan duration: %s)\n"
-	// legacyStreamFormatOnError with red color
-	legacyStreamFinishErrFormat = "\x1b[91;1mCluster [%s][%s]: caught error: \"%s\"\x1b[0m (Total plan duration: %s)\n"
-
-	// These formats are used when the plan has not yet finished.
-	legacyStreamFormat    = "Cluster [%s][%s]: running step \"%s\" (Plan duration %s)...\n"
-	legacyStreamErrFormat = "Cluster [%s][%s]: running step \"%s\" caught error: \"%s\" (Plan duration %s)...\n"
-)
-
-// Deployment format (Current).
+// Deployment format.
 const (
 	// streamFinishFormat with green color
 	streamFinishFormat = "\x1b[92;mDeployment [%s] - [%s][%s]: finished running all the plan steps\x1b[0m (Total plan duration: %s)\n"

--- a/pkg/plan/track_response.go
+++ b/pkg/plan/track_response.go
@@ -41,16 +41,12 @@ type TrackResponse struct {
 	runningStep bool
 }
 
-func (res TrackResponse) Error() error {
+func (res TrackResponse) Error() string {
 	if res.Err == nil {
-		return nil
+		return ""
 	}
 
-	if res.DeploymentID == "" {
-		return fmt.Errorf("cluster [%s][%s] %s", res.ID, res.Kind, res.Err.Error())
-	}
-
-	return fmt.Errorf(
+	return fmt.Sprintf(
 		"deployment [%s] - [%s][%s]: caught error: \"%s\"",
 		res.DeploymentID, res.Kind, res.ID, res.Err.Error(),
 	)
@@ -76,20 +72,11 @@ func formatFinishedStep(res TrackResponse, kind string) string {
 	}
 
 	if res.Err != nil && res.Err != ErrPlanFinished {
-		if res.DeploymentID == "" {
-			return fmt.Sprintf(legacyStreamFinishErrFormat,
-				res.ID, kind, res.Err, res.Duration,
-			)
-		}
-
 		return fmt.Sprintf(streamFinishErrFormat,
 			res.DeploymentID, kind, res.ID, res.Err, res.Duration,
 		)
 	}
 
-	if res.DeploymentID == "" {
-		return fmt.Sprintf(legacyStreamFinishFormat, res.ID, kind, res.Duration)
-	}
 	return fmt.Sprintf(streamFinishFormat,
 		res.DeploymentID, kind, res.ID, res.Duration,
 	)
@@ -100,11 +87,6 @@ func formatErrStep(res TrackResponse, kind string) string {
 		return ""
 	}
 
-	if res.DeploymentID == "" {
-		return fmt.Sprintf(legacyStreamErrFormat,
-			res.ID, kind, res.Step, res.Err, res.Duration,
-		)
-	}
 	return fmt.Sprintf(streamErrFormat, res.DeploymentID,
 		kind, res.ID, res.Step, res.Err, res.Duration,
 	)
@@ -117,9 +99,6 @@ func formatRunningStep(res TrackResponse, kind string) string {
 		return ""
 	}
 
-	if res.DeploymentID == "" {
-		return fmt.Sprintf(legacyStreamFormat, res.ID, kind, res.Step, res.Duration)
-	}
 	return fmt.Sprintf(streamFormat, res.DeploymentID,
 		kind, res.ID, res.Step, res.Duration,
 	)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Introduces a series of changes which allow the `allocator.Vacate()` to
return a multierror which can serialize the errors to JSON format.

To do so, multiple changes have been made throughout multiple packages,
providing building blocks for other APIs to leverage these, or use on-
demand.

`multierror.WithFormat()`: modifies a `multierror.Prefixed` or hashicorp
`multierror.Error` format functions which instead of formatting with a
"text" format, return a JSON formatted string.

`apierror.JSONError{}`: wrapping any `string` with this type, will make
it compatible to `json.Marshal`-ed. A `apierror.NewJSONError()` func is
provided for convenience too, allowing errors to be wrapped in the type.

`plan.StreamJSON`: has been fixed to return the final `error` result in
JSON formatted form.

`plan`: Legacy format has now been removed since it's no longer used.

`allocatorapi.VacateError`: now used for most of the returned vacate
errors since it supports both text and JSON formats.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Resolves #164 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
