### PR TITLE
trafficfilterapi: Add CRUD and association APIs

### DIFF
--- a/pkg/api/deploymentapi/trafficfilterapi/create.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/create.go
@@ -44,7 +44,7 @@ func (params CreateParams) Validate() error {
 	}
 
 	if params.Req == nil {
-		merr = merr.Append(errors.New("request payload cannot be empty"))
+		merr = merr.Append(errors.New("request payload is not specified and is required for the operation"))
 	}
 
 	return merr.ErrorOrNil()

--- a/pkg/api/deploymentapi/trafficfilterapi/create.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/create.go
@@ -1,0 +1,69 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments_traffic_filter"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// CreateParams is consumed by Create.
+type CreateParams struct {
+	// Required API instance.
+	*api.API
+
+	// Required create request.
+	Req *models.TrafficFilterRulesetRequest
+}
+
+// Validate ensures the parameters are usable by Create.
+func (params CreateParams) Validate() error {
+	var merr = multierror.NewPrefixed("invalid traffic filter create params")
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	if params.Req == nil {
+		merr = merr.Append(errors.New("request payload cannot be empty"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Create creates a new traffic filter matching the specified request.
+func Create(params CreateParams) (*models.TrafficFilterRulesetResponse, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.V1API.DeploymentsTrafficFilter.CreateTrafficFilterRuleset(
+		deployments_traffic_filter.NewCreateTrafficFilterRulesetParams().
+			WithBody(params.Req),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/create_association.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/create_association.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments_traffic_filter"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// CreateAssociationParams is consumed by CreateAssociation.
+type CreateAssociationParams struct {
+	// Required API instance.
+	*api.API
+
+	// Required ruleset identifier.
+	ID string
+
+	// Required entity identifier.
+	EntityID string
+
+	// Required ruleset type ("deployment" or "cluster").
+	EntityType string
+}
+
+// Validate ensures the parameters are usable by CreateAssociation.
+func (params CreateAssociationParams) Validate() error {
+	var merr = multierror.NewPrefixed("invalid traffic filter association create params")
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	if params.ID == "" {
+		merr = merr.Append(errors.New("rule set id cannot be empty"))
+	}
+
+	if params.EntityID == "" {
+		merr = merr.Append(errors.New("entity id cannot be empty"))
+	}
+
+	if params.ID == "" {
+		merr = merr.Append(errors.New("entity type cannot be empty"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// CreateAssociation creates a new traffic filter association to the specified
+// entity.
+func CreateAssociation(params CreateAssociationParams) error {
+	if err := params.Validate(); err != nil {
+		return err
+	}
+
+	_, _, err := params.V1API.DeploymentsTrafficFilter.CreateTrafficFilterRulesetAssociation(
+		deployments_traffic_filter.NewCreateTrafficFilterRulesetAssociationParams().
+			WithRulesetID(params.ID).
+			WithBody(&models.FilterAssociation{
+				ID: &params.EntityID, EntityType: &params.EntityType,
+			}),
+		params.AuthWriter,
+	)
+	return api.UnwrapError(err)
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/create_association.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/create_association.go
@@ -50,15 +50,15 @@ func (params CreateAssociationParams) Validate() error {
 	}
 
 	if params.ID == "" {
-		merr = merr.Append(errors.New("rule set id cannot be empty"))
+		merr = merr.Append(errors.New("rule set id is not specified and is required for the operation"))
 	}
 
 	if params.EntityID == "" {
-		merr = merr.Append(errors.New("entity id cannot be empty"))
+		merr = merr.Append(errors.New("entity id is not specified and is required for the operation"))
 	}
 
 	if params.ID == "" {
-		merr = merr.Append(errors.New("entity type cannot be empty"))
+		merr = merr.Append(errors.New("entity type is not specified and is required for the operation"))
 	}
 
 	return merr.ErrorOrNil()

--- a/pkg/api/deploymentapi/trafficfilterapi/create_association_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/create_association_test.go
@@ -1,0 +1,86 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+func TestCreateAssociation(t *testing.T) {
+	type args struct {
+		params CreateAssociationParams
+	}
+	tests := []struct {
+		name string
+		args args
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid traffic filter association create params",
+				apierror.ErrMissingAPI,
+				errors.New("rule set id cannot be empty"),
+				errors.New("entity id cannot be empty"),
+				errors.New("entity type cannot be empty"),
+			),
+		},
+		{
+			name: "succeeds",
+			args: args{params: CreateAssociationParams{
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Host:   api.DefaultMockHost,
+						Header: api.DefaultWriteMockHeaders,
+						Path:   "/api/v1/deployments/traffic-filter/rulesets/some-id/associations",
+						Method: "POST",
+						Body:   mock.NewStringBody(`{"entity_type":"deployment","id":"some-entity-id"}` + "\n"),
+					},
+					mock.NewStringBody("{}"),
+				)),
+				ID:         "some-id",
+				EntityID:   "some-entity-id",
+				EntityType: "deployment",
+			}},
+		},
+		{
+			name: "fails",
+			args: args{params: CreateAssociationParams{
+				API:        api.NewMock(mock.SampleInternalError()),
+				ID:         "some-id",
+				EntityID:   "some-entity-id",
+				EntityType: "deployment",
+			}},
+			err: mock.MultierrorInternalError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CreateAssociation(tt.args.params); !assert.Equal(t, tt.err, err) {
+				t.Errorf("CreateAssociation() error = %v, wantErr %v", err, tt.err)
+			}
+		})
+	}
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/create_association_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/create_association_test.go
@@ -42,9 +42,9 @@ func TestCreateAssociation(t *testing.T) {
 			name: "fails due to parameter validation",
 			err: multierror.NewPrefixed("invalid traffic filter association create params",
 				apierror.ErrMissingAPI,
-				errors.New("rule set id cannot be empty"),
-				errors.New("entity id cannot be empty"),
-				errors.New("entity type cannot be empty"),
+				errors.New("rule set id is not specified and is required for the operation"),
+				errors.New("entity id is not specified and is required for the operation"),
+				errors.New("entity type is not specified and is required for the operation"),
 			),
 		},
 		{

--- a/pkg/api/deploymentapi/trafficfilterapi/create_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/create_test.go
@@ -45,7 +45,7 @@ func TestCreate(t *testing.T) {
 			name: "fails due to parameter validation",
 			err: multierror.NewPrefixed("invalid traffic filter create params",
 				apierror.ErrMissingAPI,
-				errors.New("request payload cannot be empty"),
+				errors.New("request payload is not specified and is required for the operation"),
 			),
 		},
 		{

--- a/pkg/api/deploymentapi/trafficfilterapi/create_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/create_test.go
@@ -1,0 +1,104 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestCreate(t *testing.T) {
+	type args struct {
+		params CreateParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.TrafficFilterRulesetResponse
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid traffic filter create params",
+				apierror.ErrMissingAPI,
+				errors.New("request payload cannot be empty"),
+			),
+		},
+		{
+			name: "succeeds",
+			args: args{params: CreateParams{
+				API: api.NewMock(mock.New201ResponseAssertion(
+					&mock.RequestAssertion{
+						Host:   api.DefaultMockHost,
+						Header: api.DefaultWriteMockHeaders,
+						Method: "POST",
+						Path:   "/api/v1/deployments/traffic-filter/rulesets",
+						Body:   mock.NewStringBody(`{"include_by_default":false,"name":"some name","region":"us-east-1","rules":[{"source":"0.0.0.0/0"}],"type":"ip"}` + "\n"),
+					},
+					mock.NewStringBody(`{"id": "some-id"}`),
+				)),
+				Req: &models.TrafficFilterRulesetRequest{
+					IncludeByDefault: ec.Bool(false),
+					Name:             ec.String("some name"),
+					Region:           ec.String("us-east-1"),
+					Type:             ec.String("ip"),
+					Rules: []*models.TrafficFilterRule{{
+						Source: ec.String("0.0.0.0/0"),
+					}},
+				},
+			}},
+			want: &models.TrafficFilterRulesetResponse{
+				ID: ec.String("some-id"),
+			},
+		},
+		{
+			name: "fails",
+			args: args{params: CreateParams{
+				API: api.NewMock(mock.SampleInternalError()),
+				Req: &models.TrafficFilterRulesetRequest{
+					IncludeByDefault: ec.Bool(false),
+					Name:             ec.String("some name"),
+					Region:           ec.String("us-east-1"),
+					Type:             ec.String("ip"),
+					Rules: []*models.TrafficFilterRule{{
+						Source: ec.String("0.0.0.0/0"),
+					}},
+				},
+			}},
+			err: mock.MultierrorInternalError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Create(tt.args.params)
+			if !assert.Equal(t, tt.err, err) {
+				t.Error(err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/delete.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/delete.go
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments_traffic_filter"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// DeleteParams is consumed by Delete.
+type DeleteParams struct {
+	// Required API instance.
+	*api.API
+
+	// Required rule identifier.
+	ID string
+
+	// Optionally ignore the existing rule associations.
+	IgnoreAssociations bool
+}
+
+// Validate ensures the parameters are usable by Delete.
+func (params DeleteParams) Validate() error {
+	var merr = multierror.NewPrefixed("invalid traffic filter delete params")
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	if params.ID == "" {
+		merr = merr.Append(errors.New("rule set id cannot be empty"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Delete removes an existing traffic filter rule.
+func Delete(params DeleteParams) error {
+	if err := params.Validate(); err != nil {
+		return err
+	}
+	return api.ReturnErrOnly(
+		params.V1API.DeploymentsTrafficFilter.DeleteTrafficFilterRuleset(
+			deployments_traffic_filter.NewDeleteTrafficFilterRulesetParams().
+				WithIgnoreAssociations(&params.IgnoreAssociations).
+				WithRulesetID(params.ID),
+			params.AuthWriter,
+		),
+	)
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/delete.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/delete.go
@@ -46,7 +46,7 @@ func (params DeleteParams) Validate() error {
 	}
 
 	if params.ID == "" {
-		merr = merr.Append(errors.New("rule set id cannot be empty"))
+		merr = merr.Append(errors.New("rule set id is not specified and is required for the operation"))
 	}
 
 	return merr.ErrorOrNil()

--- a/pkg/api/deploymentapi/trafficfilterapi/delete_association.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/delete_association.go
@@ -1,0 +1,82 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments_traffic_filter"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// DeleteAssociationParams is consumed by DeleteAssociation.
+type DeleteAssociationParams struct {
+	// Required API instance.
+	*api.API
+
+	// Required ruleset identifier.
+	ID string
+
+	// Required entity identifier.
+	EntityID string
+
+	// Required ruleset type ("deployment" or "cluster").
+	EntityType string
+}
+
+// Validate ensures the parameters are usable by DeleteAssociation.
+func (params DeleteAssociationParams) Validate() error {
+	var merr = multierror.NewPrefixed("invalid traffic filter association delete params")
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	if params.ID == "" {
+		merr = merr.Append(errors.New("rule set id cannot be empty"))
+	}
+
+	if params.EntityID == "" {
+		merr = merr.Append(errors.New("entity id cannot be empty"))
+	}
+
+	if params.ID == "" {
+		merr = merr.Append(errors.New("entity type cannot be empty"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// DeleteAssociation deletes a new traffic filter association to the specified
+// entity.
+func DeleteAssociation(params DeleteAssociationParams) error {
+	if err := params.Validate(); err != nil {
+		return err
+	}
+
+	return api.ReturnErrOnly(
+		params.V1API.DeploymentsTrafficFilter.DeleteTrafficFilterRulesetAssociation(
+			deployments_traffic_filter.NewDeleteTrafficFilterRulesetAssociationParams().
+				WithRulesetID(params.ID).
+				WithAssociatedEntityID(params.EntityID).
+				WithAssociationType(params.EntityType),
+			params.AuthWriter,
+		),
+	)
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/delete_association.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/delete_association.go
@@ -49,15 +49,15 @@ func (params DeleteAssociationParams) Validate() error {
 	}
 
 	if params.ID == "" {
-		merr = merr.Append(errors.New("rule set id cannot be empty"))
+		merr = merr.Append(errors.New("rule set id is not specified and is required for the operation"))
 	}
 
 	if params.EntityID == "" {
-		merr = merr.Append(errors.New("entity id cannot be empty"))
+		merr = merr.Append(errors.New("entity id is not specified and is required for the operation"))
 	}
 
 	if params.ID == "" {
-		merr = merr.Append(errors.New("entity type cannot be empty"))
+		merr = merr.Append(errors.New("entity type is not specified and is required for the operation"))
 	}
 
 	return merr.ErrorOrNil()

--- a/pkg/api/deploymentapi/trafficfilterapi/delete_association_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/delete_association_test.go
@@ -1,0 +1,85 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+func TestDeleteAssociation(t *testing.T) {
+	type args struct {
+		params DeleteAssociationParams
+	}
+	tests := []struct {
+		name string
+		args args
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid traffic filter association delete params",
+				apierror.ErrMissingAPI,
+				errors.New("rule set id cannot be empty"),
+				errors.New("entity id cannot be empty"),
+				errors.New("entity type cannot be empty"),
+			),
+		},
+		{
+			name: "succeeds",
+			args: args{params: DeleteAssociationParams{
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Host:   api.DefaultMockHost,
+						Header: api.DefaultWriteMockHeaders,
+						Path:   "/api/v1/deployments/traffic-filter/rulesets/some-id/associations/deployment/some-entity-id",
+						Method: "DELETE",
+					},
+					mock.NewStringBody("{}"),
+				)),
+				ID:         "some-id",
+				EntityID:   "some-entity-id",
+				EntityType: "deployment",
+			}},
+		},
+		{
+			name: "fails",
+			args: args{params: DeleteAssociationParams{
+				API:        api.NewMock(mock.SampleInternalError()),
+				ID:         "some-id",
+				EntityID:   "some-entity-id",
+				EntityType: "deployment",
+			}},
+			err: mock.MultierrorInternalError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := DeleteAssociation(tt.args.params); !assert.Equal(t, tt.err, err) {
+				t.Errorf("DeleteAssociation() error = %v, wantErr %v", err, tt.err)
+			}
+		})
+	}
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/delete_association_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/delete_association_test.go
@@ -42,9 +42,9 @@ func TestDeleteAssociation(t *testing.T) {
 			name: "fails due to parameter validation",
 			err: multierror.NewPrefixed("invalid traffic filter association delete params",
 				apierror.ErrMissingAPI,
-				errors.New("rule set id cannot be empty"),
-				errors.New("entity id cannot be empty"),
-				errors.New("entity type cannot be empty"),
+				errors.New("rule set id is not specified and is required for the operation"),
+				errors.New("entity id is not specified and is required for the operation"),
+				errors.New("entity type is not specified and is required for the operation"),
 			),
 		},
 		{

--- a/pkg/api/deploymentapi/trafficfilterapi/delete_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/delete_test.go
@@ -43,7 +43,7 @@ func TestDelete(t *testing.T) {
 			name: "fails due to parameter validation",
 			err: multierror.NewPrefixed("invalid traffic filter delete params",
 				apierror.ErrMissingAPI,
-				errors.New("rule set id cannot be empty"),
+				errors.New("rule set id is not specified and is required for the operation"),
 			),
 		},
 		{

--- a/pkg/api/deploymentapi/trafficfilterapi/delete_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/delete_test.go
@@ -1,0 +1,102 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+func TestDelete(t *testing.T) {
+	type args struct {
+		params DeleteParams
+	}
+	tests := []struct {
+		name string
+		args args
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid traffic filter delete params",
+				apierror.ErrMissingAPI,
+				errors.New("rule set id cannot be empty"),
+			),
+		},
+		{
+			name: "succeeds",
+			args: args{params: DeleteParams{
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Host:   api.DefaultMockHost,
+						Header: api.DefaultWriteMockHeaders,
+						Method: "DELETE",
+						Path:   "/api/v1/deployments/traffic-filter/rulesets/some-id",
+						Query: url.Values{
+							"ignore_associations": []string{"false"},
+						},
+					},
+					mock.NewStringBody(`{"id": "some-id"}`),
+				)),
+				ID: "some-id",
+			}},
+		},
+		{
+			name: "succeeds with IgnoreAssociations",
+			args: args{params: DeleteParams{
+				ID:                 "some-id",
+				IgnoreAssociations: true,
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Host:   api.DefaultMockHost,
+						Header: api.DefaultWriteMockHeaders,
+						Method: "DELETE",
+						Path:   "/api/v1/deployments/traffic-filter/rulesets/some-id",
+						Query: url.Values{
+							"ignore_associations": []string{"true"},
+						},
+					},
+					mock.NewStringBody(`{"id": "some-id"}`),
+				)),
+			}},
+		},
+		{
+			name: "fails",
+			args: args{params: DeleteParams{
+				API: api.NewMock(mock.SampleInternalError()),
+				ID:  "some-id",
+			}},
+			err: mock.MultierrorInternalError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Delete(tt.args.params); !assert.Equal(t, tt.err, err) {
+				t.Errorf("Delete() error = %v, wantErr %v", err, tt.err)
+			}
+		})
+	}
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/get.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/get.go
@@ -1,0 +1,73 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments_traffic_filter"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// GetParams is consumed by Get.
+type GetParams struct {
+	// Required API instance.
+	*api.API
+
+	// Required rule identifier.
+	ID string
+
+	// Optionally include the rule associations.
+	IncludeAssociations bool
+}
+
+// Validate ensures the parameters are usable by Get.
+func (params GetParams) Validate() error {
+	var merr = multierror.NewPrefixed("invalid traffic filter get params")
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	if params.ID == "" {
+		merr = merr.Append(errors.New("rule set id cannot be empty"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Get obtains an existing traffic filter.
+func Get(params GetParams) (*models.TrafficFilterRulesetInfo, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.V1API.DeploymentsTrafficFilter.GetTrafficFilterRuleset(
+		deployments_traffic_filter.NewGetTrafficFilterRulesetParams().
+			WithRulesetID(params.ID).
+			WithIncludeAssociations(&params.IncludeAssociations),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/get.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/get.go
@@ -47,7 +47,7 @@ func (params GetParams) Validate() error {
 	}
 
 	if params.ID == "" {
-		merr = merr.Append(errors.New("rule set id cannot be empty"))
+		merr = merr.Append(errors.New("rule set id is not specified and is required for the operation"))
 	}
 
 	return merr.ErrorOrNil()

--- a/pkg/api/deploymentapi/trafficfilterapi/get_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/get_test.go
@@ -1,0 +1,116 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestGet(t *testing.T) {
+	type args struct {
+		params GetParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.TrafficFilterRulesetInfo
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid traffic filter get params",
+				apierror.ErrMissingAPI,
+				errors.New("rule set id cannot be empty"),
+			),
+		},
+		{
+			name: "succeeds",
+			args: args{params: GetParams{
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Host:   api.DefaultMockHost,
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Path:   "/api/v1/deployments/traffic-filter/rulesets/some-id",
+						Query: url.Values{
+							"include_associations": []string{"false"},
+						},
+					},
+					mock.NewStringBody(`{"id": "some-id"}`),
+				)),
+				ID: "some-id",
+			}},
+			want: &models.TrafficFilterRulesetInfo{
+				ID: ec.String("some-id"),
+			},
+		},
+		{
+			name: "succeeds with IncludeAssociations",
+			args: args{params: GetParams{
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Host:   api.DefaultMockHost,
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Path:   "/api/v1/deployments/traffic-filter/rulesets/some-id",
+						Query: url.Values{
+							"include_associations": []string{"true"},
+						},
+					},
+					mock.NewStringBody(`{"id": "some-id", "associations": [{"id": "some-id", "entity_type": "deployment"}]}`),
+				)),
+				IncludeAssociations: true,
+				ID:                  "some-id",
+			}},
+			want: &models.TrafficFilterRulesetInfo{
+				ID: ec.String("some-id"),
+				Associations: []*models.FilterAssociation{
+					{ID: ec.String("some-id"), EntityType: ec.String("deployment")},
+				},
+			},
+		},
+		{
+			name: "fails",
+			args: args{params: GetParams{
+				API: api.NewMock(mock.SampleInternalError()),
+				ID:  "some-id",
+			}},
+			err: mock.MultierrorInternalError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Get(tt.args.params)
+			if !assert.Equal(t, tt.err, err) {
+				t.Error(err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/get_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/get_test.go
@@ -46,7 +46,7 @@ func TestGet(t *testing.T) {
 			name: "fails due to parameter validation",
 			err: multierror.NewPrefixed("invalid traffic filter get params",
 				apierror.ErrMissingAPI,
-				errors.New("rule set id cannot be empty"),
+				errors.New("rule set id is not specified and is required for the operation"),
 			),
 		},
 		{

--- a/pkg/api/deploymentapi/trafficfilterapi/list.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/list.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments_traffic_filter"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// ListParams is consumed by List.
+type ListParams struct {
+	// Required API instance.
+	*api.API
+
+	// Optionally return only the traffic filters for a region.
+	Region string
+
+	// Optionally include the rule associations.
+	IncludeAssociations bool
+}
+
+// Validate ensures the parameters are usable by List.
+func (params ListParams) Validate() error {
+	var merr = multierror.NewPrefixed("invalid traffic filter list params")
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// List returns all the created traffic filters for a region.
+func List(params ListParams) (*models.TrafficFilterRulesets, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	p := deployments_traffic_filter.NewGetTrafficFilterRulesetsParams().
+		WithIncludeAssociations(&params.IncludeAssociations)
+	if params.Region != "" {
+		p.SetRegion(&params.Region)
+	}
+
+	res, err := params.V1API.DeploymentsTrafficFilter.GetTrafficFilterRulesets(
+		p, params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/list_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/list_test.go
@@ -1,0 +1,114 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestList(t *testing.T) {
+	type args struct {
+		params ListParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.TrafficFilterRulesets
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid traffic filter list params",
+				apierror.ErrMissingAPI,
+			),
+		},
+		{
+			name: "succeeds",
+			args: args{params: ListParams{
+				Region: "some-region",
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Host:   api.DefaultMockHost,
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Path:   "/api/v1/deployments/traffic-filter/rulesets",
+						Query: url.Values{
+							"region":               []string{"some-region"},
+							"include_associations": []string{"false"},
+						},
+					},
+					mock.NewStringBody(`{"rulesets": [{"id": "some-id"}]}`),
+				)),
+			}},
+			want: &models.TrafficFilterRulesets{Rulesets: []*models.TrafficFilterRulesetInfo{{
+				ID: ec.String("some-id"),
+			}}},
+		},
+		{
+			name: "succeeds with IncludeAssociations and no region",
+			args: args{params: ListParams{
+				IncludeAssociations: true,
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Host:   api.DefaultMockHost,
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Path:   "/api/v1/deployments/traffic-filter/rulesets",
+						Query: url.Values{
+							"include_associations": []string{"true"},
+						},
+					},
+					mock.NewStringBody(`{"rulesets": [{"id": "some-id", "associations": [{"id": "some-id", "entity_type": "deployment"}]}]}`),
+				)),
+			}},
+			want: &models.TrafficFilterRulesets{Rulesets: []*models.TrafficFilterRulesetInfo{{
+				ID: ec.String("some-id"),
+				Associations: []*models.FilterAssociation{
+					{ID: ec.String("some-id"), EntityType: ec.String("deployment")},
+				},
+			}}},
+		},
+		{
+			name: "fails",
+			args: args{params: ListParams{
+				API:    api.NewMock(mock.SampleInternalError()),
+				Region: "some-region",
+			}},
+			err: mock.MultierrorInternalError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := List(tt.args.params)
+			if !assert.Equal(t, tt.err, err) {
+				t.Error(err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/update.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/update.go
@@ -47,11 +47,11 @@ func (params UpdateParams) Validate() error {
 	}
 
 	if params.ID == "" {
-		merr = merr.Append(errors.New("rule set id cannot be empty"))
+		merr = merr.Append(errors.New("rule set id is not specified and is required for the operation"))
 	}
 
 	if params.Req == nil {
-		merr = merr.Append(errors.New("request payload cannot be empty"))
+		merr = merr.Append(errors.New("request payload is not specified and is required for the operation"))
 	}
 
 	return merr.ErrorOrNil()

--- a/pkg/api/deploymentapi/trafficfilterapi/update.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/update.go
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments_traffic_filter"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// UpdateParams is consumed by Update.
+type UpdateParams struct {
+	// Required API instance.
+	*api.API
+
+	// Required rule identifier.
+	ID string
+
+	// Required Update request.
+	Req *models.TrafficFilterRulesetRequest
+}
+
+// Validate ensures the parameters are usable by Update.
+func (params UpdateParams) Validate() error {
+	var merr = multierror.NewPrefixed("invalid traffic filter update params")
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	if params.ID == "" {
+		merr = merr.Append(errors.New("rule set id cannot be empty"))
+	}
+
+	if params.Req == nil {
+		merr = merr.Append(errors.New("request payload cannot be empty"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Update updates an existing traffic filter to match the specified request.
+func Update(params UpdateParams) (*models.TrafficFilterRulesetResponse, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.V1API.DeploymentsTrafficFilter.UpdateTrafficFilterRuleset(
+		deployments_traffic_filter.NewUpdateTrafficFilterRulesetParams().
+			WithRulesetID(params.ID).
+			WithBody(params.Req),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, api.UnwrapError(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/update_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/update_test.go
@@ -1,0 +1,99 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trafficfilterapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestUpdate(t *testing.T) {
+	type args struct {
+		params UpdateParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.TrafficFilterRulesetResponse
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid traffic filter update params",
+				apierror.ErrMissingAPI,
+				errors.New("rule set id cannot be empty"),
+				errors.New("request payload cannot be empty"),
+			),
+		},
+		{
+			name: "succeeds",
+			args: args{params: UpdateParams{
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Host:   api.DefaultMockHost,
+						Header: api.DefaultWriteMockHeaders,
+						Method: "PUT",
+						Path:   "/api/v1/deployments/traffic-filter/rulesets/some-id",
+						Body:   mock.NewStringBody(`{"include_by_default":false,"name":"some name","region":"us-east-1","rules":[{"source":"0.0.0.0/0"}],"type":"ip"}` + "\n"),
+					},
+					mock.NewStringBody(`{"id": "some-id"}`),
+				)),
+				ID: "some-id",
+				Req: &models.TrafficFilterRulesetRequest{
+					IncludeByDefault: ec.Bool(false),
+					Name:             ec.String("some name"),
+					Region:           ec.String("us-east-1"),
+					Type:             ec.String("ip"),
+					Rules: []*models.TrafficFilterRule{{
+						Source: ec.String("0.0.0.0/0"),
+					}},
+				},
+			}},
+			want: &models.TrafficFilterRulesetResponse{
+				ID: ec.String("some-id"),
+			},
+		},
+		{
+			name: "fails",
+			args: args{params: UpdateParams{
+				API: api.NewMock(mock.SampleInternalError()),
+				ID:  "some-id",
+				Req: &models.TrafficFilterRulesetRequest{},
+			}},
+			err: mock.MultierrorInternalError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Update(tt.args.params)
+			if !assert.Equal(t, tt.err, err) {
+				t.Error(err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/api/deploymentapi/trafficfilterapi/update_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/update_test.go
@@ -45,8 +45,8 @@ func TestUpdate(t *testing.T) {
 			name: "fails due to parameter validation",
 			err: multierror.NewPrefixed("invalid traffic filter update params",
 				apierror.ErrMissingAPI,
-				errors.New("rule set id cannot be empty"),
-				errors.New("request payload cannot be empty"),
+				errors.New("rule set id is not specified and is required for the operation"),
+				errors.New("request payload is not specified and is required for the operation"),
 			),
 		},
 		{


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds an implementation for the traffic filtering APIs so they can be
leveraged in the terraform provider

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Depends on #203 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

