### PR TITLE
deploymentapi: Add ConvertLegacyPlans to Get

### DIFF
--- a/pkg/api/deploymentapi/get.go
+++ b/pkg/api/deploymentapi/get.go
@@ -31,11 +31,17 @@ var systemAlerts = ec.Int64(5)
 
 // GetParams is consumed by get resource functions
 type GetParams struct {
+	// Required API instance.
 	*api.API
+
+	// Required Deployment identifier.
 	DeploymentID string
 
 	// Optional parameters
 	deputil.QueryParams
+
+	// Optionally convert the legacy plans to the current deployment format.
+	ConvertLegacyPlans bool
 
 	// RefID, when specified, skips auto-discovering the deployment resource
 	// RefID and instead uses the one that's passed.
@@ -71,6 +77,7 @@ func Get(params GetParams) (*models.DeploymentGetResponse, error) {
 			WithShowPlanHistory(ec.Bool(params.ShowPlanHistory)).
 			WithShowMetadata(ec.Bool(params.ShowMetadata)).
 			WithShowSettings(ec.Bool(params.ShowSettings)).
+			WithConvertLegacyPlans(ec.Bool(params.ConvertLegacyPlans)).
 			WithShowSystemAlerts(systemAlerts),
 		params.AuthWriter,
 	)

--- a/pkg/api/deploymentapi/get_test.go
+++ b/pkg/api/deploymentapi/get_test.go
@@ -155,6 +155,43 @@ func TestGet(t *testing.T) {
 				ID:      ec.String("f1d329b0fb34470ba8b18361cabdd2bc"),
 			},
 		},
+		{
+			name: "Get succeeds with ConvertLegacyPlans",
+			args: args{
+				params: GetParams{
+					DeploymentID:       "f1d329b0fb34470ba8b18361cabdd2bc",
+					ConvertLegacyPlans: true,
+					API: api.NewMock(mock.Response{
+						Response: http.Response{
+							Body:       mock.NewStringBody(getResponse),
+							StatusCode: 200,
+						},
+						Assert: &mock.RequestAssertion{
+							Header: api.DefaultReadMockHeaders,
+							Method: "GET",
+							Host:   api.DefaultMockHost,
+							Path:   "/api/v1/deployments/f1d329b0fb34470ba8b18361cabdd2bc",
+							Query: url.Values{
+								"convert_legacy_plans": {"true"},
+								"enrich_with_template": {"true"},
+								"show_metadata":        {"false"},
+								"show_plan_defaults":   {"false"},
+								"show_plan_history":    {"false"},
+								"show_plan_logs":       {"false"},
+								"show_plans":           {"false"},
+								"show_security":        {"false"},
+								"show_settings":        {"false"},
+								"show_system_alerts":   {"5"},
+							},
+						},
+					}),
+				},
+			},
+			want: &models.DeploymentGetResponse{
+				Healthy: ec.Bool(true),
+				ID:      ec.String("f1d329b0fb34470ba8b18361cabdd2bc"),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new optional boolean to `deploymentapi.Get()` which allows users
to optionally convert the legacy plan format to the current format.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add the option to convert pre-2.x ECE plans

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
