### PR TITLE
go: Update to go 1.15

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
       id: go
 
     - name: Check out code into the Go module directory

--- a/internal/cmd/apivalidator/requests/run_test.go
+++ b/internal/cmd/apivalidator/requests/run_test.go
@@ -69,7 +69,7 @@ func TestRun(t *testing.T) {
 			want: 5,
 			wantErr: multierror.NewPrefixed("api spec validation",
 				//nolint - error strings should not be capitalized or end with punctuation or a newline
-				errors.New("Post http://0.0.0.0:1234/deployments/_search: connection refused"),
+				errors.New(`Post "http://0.0.0.0:1234/deployments/_search": connection refused`),
 			),
 		},
 		{
@@ -82,7 +82,7 @@ func TestRun(t *testing.T) {
 			}},
 			want: 2,
 			//nolint - error strings should not be capitalized or end with punctuation or a newline
-			wantErr: errors.New("Get https://example.co/hola: no such host"),
+			wantErr: errors.New(`Get "https://example.co/hola": no such host`),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/api/platformapi/allocatorapi/vacate_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_test.go
@@ -1141,7 +1141,7 @@ func Test_fillVacateClusterParams(t *testing.T) {
 					Output:    output.NewDevice(new(bytes.Buffer)),
 				},
 			},
-			err: errors.New(`allocator allocator-1: resource id [3ee11eb40eda22cac0cce259625c6734][elasticsearch]: allocator health autodiscovery: Get https://mock.elastic.co/api/v1/regions/us-east-1/platform/infrastructure/allocators/allocator-1: unauthorized`),
+			err: errors.New(`allocator allocator-1: resource id [3ee11eb40eda22cac0cce259625c6734][elasticsearch]: allocator health autodiscovery: Get "https://mock.elastic.co/api/v1/regions/us-east-1/platform/infrastructure/allocators/allocator-1": unauthorized`),
 		},
 		{
 			name: "sets defaults on parameters that aren't specified",


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail. -->
We've been on go `1.13` for a while and go 1.15 is out and has many
advantages over go `1.15`. This patch updates to the new version and
fixes the tests which are broken as part of the upgrade

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Live in the present!

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)
