### PR TITLE
sync/pool: Add FailFast parameter, stopping on err

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - funlen
     - wsl
     - gomnd
+    - maligned
 linters-settings:
   govet:
     check-shadowing: false

--- a/pkg/sync/pool/pool.go
+++ b/pkg/sync/pool/pool.go
@@ -133,7 +133,7 @@ type Pool struct {
 	// writer where any (log, info) messages will be sent.
 	writer io.Writer
 
-	// FailFast can be set to stop all the pool when any of the workers returns
+	// failFast can be set to stop all the pool when any of the workers returns
 	// with an error.
 	failFast bool
 }

--- a/pkg/sync/pool/pool_params.go
+++ b/pkg/sync/pool/pool_params.go
@@ -60,6 +60,10 @@ type Params struct {
 
 	// Writer is the device where any (log, info) messages will be sent.
 	Writer io.Writer
+
+	// FailFast can be set to stop all the pool when any of the workers returns
+	// with an error.
+	FailFast bool
 }
 
 // Timeout is an object that encloses different Pool operation timeouts.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This patch adds a new `FailFast` parameter to `pool.Params` which allows
consumers to toggle a new pool behavior where the pool will gracefully
stop when one of the workers returns with an error. This will stop
processing any additional work but try to continue processing the work
that's in-flight or cancel the execution when the `params.Timeout.Stop`
`time.Duration` is exceeded.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Provide more features for the deployer.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
