### PR TITLE
actions: Add scheduled api-validation job

### DIFF
--- a/.github/workflows/apivalidation.yml
+++ b/.github/workflows/apivalidation.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
         id: go
 
       - name: Set up GitHub token auth

--- a/.github/workflows/apivalidation.yml
+++ b/.github/workflows/apivalidation.yml
@@ -1,0 +1,35 @@
+name: api-validation
+
+on:
+  repository_dispatch:
+    types: api-validation-tests
+  schedule:
+    # Run every 9PM UTC
+    - cron:  '0 21 * * *'
+
+jobs:
+  api-validation:
+    name: Run API validation tests against a proxy for the ESS public API.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Set up GitHub token auth
+        run: git config --global url."https://${GITHUB_TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_MARCLOP }}
+
+      - name: Start proxy server and run API validation tests
+        id: proxy
+        run: make validation-proxy & make wait-on-proxy && make api-validation
+        env:
+          EC_API_KEY: ${{ secrets.EC_API_KEY }}
+          RELEASE_BRANCH: 1.0
+          APISPEC_FILENAME: apidocs-user.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ We have [good first issues](https://github.com/elastic/cloud-sdk-go/labels/good%
   - [Setting up your fork](#setting-up-your-fork)
 - [Development](#development)
   - [Generating the client and models from a swagger definition](#generating-the-client-and-models-from-a-swagger-definition)
-  - [Running unit tests](#running-unit-tests)
+  - [Running tests](#running-tests)
 
 ## Reporting Issues
 
@@ -175,7 +175,9 @@ Additionally, a full markdown declaration of API commands will be generated in `
 
 The Makefile global variable `ECE_VERSION` should be modified before running `make swagger`. Make sure you have set the "EC_API_KEY" environment variable locally with your Elasticsearch Service API key. This will allow the API validation tests to run
 
-### Running unit tests
+### Running tests
+
+#### Unit
 
 There's two variables that can be passed to the Makefile target:
 
@@ -183,6 +185,39 @@ There's two variables that can be passed to the Makefile target:
 - `TEST_UNIT_PACKAGE` controls which package names to test (defaults to `./...` which means all packages).
 
 The current `TEST_UNIT_FLAGS` default to: `-timeout 10s -p 4 -race -cover`.
+
+#### API Validation
+
+In order to run validation tests for our API specification against the live public API, we use the [Prism Validation Proxy](https://stoplight.io/p/docs/gh/stoplightio/prism/docs/guides/03-validation-proxy.md) alongside our custom `apivalidator` CLI.
+
+Before you run the tests or use the CLI, make sure you've got the `EC_API_KEY` environment variable set, and start the validation proxy by running:
+
+```console
+$ export EC_API_KEY=<your-api-key>
+$ make validation-proxy
+[1:43:49 AM] › [CLI] …  awaiting  Starting Prism…
+[1:43:50 AM] › [CLI] ℹ  info      GET        http://0.0.0.0:4010/deployments
+<...>
+[1:43:50 AM] › [CLI] ▶  start     Prism is listening on http://0.0.0.0:4010
+```
+
+Once the validation proxy is up and running, you can either run the validation testing suite which validates the apidocs-user.json we have on master in cloud-sdk-go by running:
+
+```console
+$ make api-validation
+```
+
+Or, you can run the CLI manually if you wish to validate an api specification from another location or from your local directory by using the `--source` flag.
+
+```console
+$ ./bin/apivalidator --source https://raw.githubusercontent.com/elastic/cloud-sdk-go/v1.0.0-beta3/api/apidocs-user.json
+```
+
+If for some reason you're running the validation proxy on a different port than the default, make sure to use the `--port` flag:
+
+```console
+$ ./bin/apivalidator --port 4123
+```
 
 #### Go test flags
 

--- a/build/Makefile.apivalidation
+++ b/build/Makefile.apivalidation
@@ -1,36 +1,37 @@
+RELEASE_BRANCH ?= 1.0
 export EXTERNAL_PORT ?= 4010
 PUBLISHED_PORT ?= $(EXTERNAL_PORT):4010
 API_LOCATION ?= https://api.elastic-cloud.com
 APISPEC_FILENAME ?= apidocs-user.json
-export APISPEC_LOCATION ?= api/$(APISPEC_FILENAME)
+export APISPEC_LOCATION ?= https://raw.githubusercontent.com/elastic/cloud-sdk-go/$(RELEASE_BRANCH)/api/$(APISPEC_FILENAME)
 PRISM_CONTAINER ?= stoplight/prism:3
+
+CURL_GITHUB_EVENT_AV_TYPE_DATA = '{"event_type": "api-validation-tests"}'
 
 #### API validation test targets
 
 ## Starts a validation proxy server to the ESS API.
 .PHONY: validation-proxy
 validation-proxy:
-	@ prism proxy $(APISPEC_LOCATION) $(API_LOCATION) --errors
+	@ docker run --init -p $(PUBLISHED_PORT) -P $(PRISM_CONTAINER) proxy -m -h 0.0.0.0 $(APISPEC_LOCATION) $(API_LOCATION) --errors
 
 ## Runs tests through a validation proxy to the ESS API in order to find discrepancies between an API specification and a target server.
 .PHONY: api-validation
-api-validation: apivalidation-deps build_apivalidator
+api-validation: apivalidation-deps
 	@ cd build/apivalidation && $(GOBIN)/gotestsum --format standard-verbose -- -tags=apivalidation -timeout=10m ./...
-
-.PHONY: build_apivalidator
-build_apivalidator:
-	@ echo "-> Building apivalidator in bin/apivalidator..."
-	@ if [[ -f bin/apivalidator ]]; then rm -f bin/apivalidator; fi
-	@ go build -o bin/apivalidator ./internal/cmd/apivalidator/
 
 .PHONY: wait-on-proxy
 wait-on-proxy:
 	@ until nc -z -w 2 localhost $(EXTERNAL_PORT); do sleep 5; done
 
 .PHONY: apivalidation-deps
-apivalidation-deps: $(GOBIN)/gobin $(GOBIN)/gotestsum $(GOBIN)/prism
+apivalidation-deps: $(GOBIN)/gobin $(GOBIN)/gotestsum $(GOBIN)/apivalidator
 
-.PHONY: run-apivalidation-tests
-run-apivalidation-tests:
-	@ make validation-proxy & make wait-on-proxy && make api-validation
-	@ ps -ef | grep [p]rism | grep -v grep | awk '{print $2}' | xargs kill
+#### GitHub interaction targets
+
+## Triggers the API validation tests against the validation proxy.
+.PHONY: trigger-github-apivalidation
+trigger-github-apivalidation:
+	@ echo "-> Sending $(CURL_GITHUB_EVENT_AV_TYPE_DATA) to $(CURL_GITHUB_DISPATCH_URL)"
+	@ curl -H $(CURL_GITHUB_ACCEPT) -H $(CURL_GITHUB_AUTHORIZATION) -XPOST \
+	--data $(CURL_GITHUB_EVENT_AV_TYPE_DATA) $(CURL_GITHUB_DISPATCH_URL)

--- a/build/Makefile.deps
+++ b/build/Makefile.deps
@@ -75,6 +75,11 @@ $(GOBIN)/prism: $(GOBIN)/gobin
 	@ curl -L https://raw.githack.com/stoplightio/prism/master/install | sh
 	@ cp /usr/local/bin/prism $(GOBIN)/prism
 
+$(GOBIN)/apivalidator: $(GOBIN)/gobin
+	@ echo "-> Installing apivalidator..."
+	@ if [[ -f bin/apivalidator ]]; then rm -f bin/apivalidator; fi
+	@ $(GOBIN)/gobin github.com/elastic/cloud-sdk-go/internal/cmd/apivalidator@master
+
 ## Downloads the required go modules.
 .PHONY: mod
 mod:

--- a/build/Makefile.swagger
+++ b/build/Makefile.swagger
@@ -24,7 +24,6 @@ swagger: deps _prepare _cleanup
 	@ $(GOBIN)/swagger generate client $(SWAGGER_GENERATE_CLIENT_FLAGS) -f $(SWAGGER_FILE) -m $(MODELS_DIR) -c $(CLIENT_DIR)
 	@ make vendor
 	@ make format
-	@ make run-apivalidation-tests
 	@ rm -f $(SWAGGER_FILE)
 	@ echo "-> Done."
 

--- a/build/apivalidation/apivalidation_test.go
+++ b/build/apivalidation/apivalidation_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	apiSpecSource = "../../" + os.Getenv("APISPEC_LOCATION")
+	apiSpecSource = os.Getenv("APISPEC_LOCATION")
 	port          = os.Getenv("EXTERNAL_PORT")
 )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Adds a new GH actions workflow to run the api-validation tests once 
a day.

Additionally, I have removed the api-validation tests on each 
`make swagger` as now we don't necessarily have the apidocs
on par with what's on production. We may have some endpoints 
that are not publicly available yet for development purposes, so 
there's no point in having these as they are likely to fail on occasion.

## How Has This Been Tested?
Running the make targets locally
 
## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

