### PR TITLE
apivalidation: Set workflow to Go 1.14

### DIFF
--- a/.github/workflows/apivalidation.yml
+++ b/.github/workflows/apivalidation.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.14
         id: go
 
       - name: Set up GitHub token auth
@@ -31,5 +31,3 @@ jobs:
         run: make validation-proxy & make wait-on-proxy && make api-validation
         env:
           EC_API_KEY: ${{ secrets.EC_API_KEY }}
-          RELEASE_BRANCH: 1.0
-          APISPEC_FILENAME: apidocs-user.json


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This PR attempts to fix the broken validation tests. This same workflow 
works fine on an internal project using go 1.13, let's try 1.14 and see if it
works.

Additionally I have removed a couple of env vars from the workflow as
they are not needed.

**Note** I have go 1.15 on my machine and the tests work just fine, 
must be a Github thing?

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

