### PR TITLE
allocatorapi: Fix incorrect json error formatting

### DIFF
--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -315,7 +315,7 @@ func VacateCluster(params *VacateClusterParams) error {
 		return nil
 	}
 
-	err = planutil.TrackChange(planutil.TrackChangeParams{
+	return planutil.TrackChange(planutil.TrackChangeParams{
 		TrackChangeParams: plan.TrackChangeParams{
 			API:              params.API,
 			ResourceID:       params.ClusterID,
@@ -329,8 +329,6 @@ func VacateCluster(params *VacateClusterParams) error {
 		Writer: params.Output,
 		Format: params.OutputFormat,
 	})
-
-	return multierror.WithFormat(err, params.OutputFormat)
 }
 
 // fillVacateClusterParams validates the parameters and fills any missing

--- a/pkg/plan/stream.go
+++ b/pkg/plan/stream.go
@@ -19,6 +19,7 @@ package plan
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 
@@ -70,6 +71,11 @@ func StreamJSON(channel <-chan TrackResponse, device io.Writer, pretty bool) err
 			_ = encoder.Encode(res)
 		}
 	})
+
+	var merr *multierror.Prefixed
+	if errors.As(err, &merr) {
+		merr.SkipPrefixing = true
+	}
 
 	return multierror.WithFormat(err, "json")
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This patch fixes the returned error format when an allocatorapi.Vacate
returns with an error.

The problem wasn't on how the errors are marshalled when OutputFormat,
but on the `multierror.Prefixed` error and the unpacking that it does.
As it turns out, because the prefix from the error from `plan.Stream()`
isn't equal to the the multi error where it is flattened to through the
`merr.Append()` (`unpackErrors()`), as it was being squashed by calling
`fmt.Sprint(prefixed.Prefix, ": ", errElement.Error()),`. Already, this
isn't ideal and probably we might want to look more closely at using the
error wrapping `fmt.Errorf("%s: %w")`, and its implications.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Invalid JSON (multi)error formatting.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)