### PR TITLE
transport: Adds another patch to unwrap the error

### DIFF
--- a/pkg/api/apierror/unwrap.go
+++ b/pkg/api/apierror/unwrap.go
@@ -135,7 +135,7 @@ func tryWrappedResponse(apiError interface{}) error {
 	res := (*http.Response)(ptr)
 	b, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return fmt.Errorf("failed reading error body")
+		return fmt.Errorf("failed reading error body: %w", err)
 	}
 	defer res.Body.Close()
 

--- a/pkg/api/transport_custom.go
+++ b/pkg/api/transport_custom.go
@@ -151,6 +151,10 @@ func (t *CustomTransport) doRoundTrip(req *http.Request) (res *http.Response, er
 
 		// Return early when err is empty or not a timeout.
 		if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+			// Necessary to be able to access the error through api.UnwrapError.
+			if res != nil {
+				_, _ = httputil.DumpResponse(res, res.Body != nil)
+			}
 			return
 		}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Two patches to be able to still be able to unwrap the error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`failed reading error body` is not a great error.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
