### PR TITLE
esremoteclustersapi: Add Get and Update functions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,7 @@ github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/cobra v1.1.0 h1:aq3wCKjTPmzcNWLVGnsFVN4rflK7Uzn10F8/aw8MhdQ=
 github.com/spf13/cobra v1.1.0/go.mod h1:yk5b0mALVusDL5fMM6Rd1wgnoO5jUPhwsQ6LQAJTidQ=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=

--- a/pkg/api/deploymentapi/esremoteclustersapi/get.go
+++ b/pkg/api/deploymentapi/esremoteclustersapi/get.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package eskeystoreapi
+package esremoteclustersapi
 
 import (
 	"github.com/elastic/cloud-sdk-go/pkg/api"
@@ -27,20 +27,22 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/util"
 )
 
-// GetParams is consumed by the Get function.
+// GetParams is consumed by Get.
 type GetParams struct {
+	// Required API instance
 	*api.API
 
+	// Required source deployment ID
 	DeploymentID string
 
-	// Optional RefID, when not specified, an API call will be issued to auto-
-	// discover the resource's RefID.
+	// Optional source ref_id. When not specified, an API call will be issued
+	// to auto-discover the resource's RefID.
 	RefID string
 }
 
-// Validate ensures the parameters are usable by Get.
+// Validate ensures the parameters are usable by the consuming function.
 func (params GetParams) Validate() error {
-	var merr = multierror.NewPrefixed("invalid elasticsearch keystore get params")
+	merr := multierror.NewPrefixed("invalid elasticsearch remote clusters api params")
 
 	if params.API == nil {
 		merr = merr.Append(apierror.ErrMissingAPI)
@@ -53,8 +55,8 @@ func (params GetParams) Validate() error {
 	return merr.ErrorOrNil()
 }
 
-// Get returns the specified deployment template.
-func Get(params GetParams) (*models.KeystoreContents, error) {
+// Get returns a response with the number of remote deployments.
+func Get(params GetParams) (*models.RemoteResources, error) {
 	if err := params.Validate(); err != nil {
 		return nil, err
 	}
@@ -68,15 +70,14 @@ func Get(params GetParams) (*models.KeystoreContents, error) {
 		return nil, err
 	}
 
-	res, err := params.V1API.Deployments.GetDeploymentEsResourceKeystore(
-		deployments.NewGetDeploymentEsResourceKeystoreParams().
+	res, err := params.V1API.Deployments.GetDeploymentEsResourceRemoteClusters(
+		deployments.NewGetDeploymentEsResourceRemoteClustersParams().
 			WithDeploymentID(params.DeploymentID).
 			WithRefID(params.RefID),
 		params.AuthWriter,
 	)
-
 	if err != nil {
-		return nil, apierror.Unwrap(err)
+		return nil, api.UnwrapError(err)
 	}
 
 	return res.Payload, nil

--- a/pkg/api/deploymentapi/esremoteclustersapi/get_test.go
+++ b/pkg/api/deploymentapi/esremoteclustersapi/get_test.go
@@ -1,0 +1,221 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package esremoteclustersapi
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestGet(t *testing.T) {
+	type args struct {
+		params GetParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.RemoteResources
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid elasticsearch remote clusters api params",
+				errors.New("api reference is required for the operation"),
+				errors.New("deployment id should have a length of 32 characters"),
+			),
+		},
+		{
+			name: "succeeds",
+			args: args{params: GetParams{
+				DeploymentID: mock.ValidClusterID,
+				RefID:        "main-elasticsearch",
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/320b7b540dfc967a7a649c18e2fce4ed/elasticsearch/main-elasticsearch/remote-clusters",
+					},
+					mock.NewStructBody(models.RemoteResources{Resources: []*models.RemoteResourceRef{
+						{
+							DeploymentID:       ec.String("first id"),
+							ElasticsearchRefID: ec.String("main-elasticsearch"),
+							Alias:              ec.String("caperucita"),
+						},
+						{
+							DeploymentID:       ec.String("second id"),
+							ElasticsearchRefID: ec.String("elasticsearch"),
+							Alias:              ec.String("bestest"),
+							SkipUnavailable:    ec.Bool(true),
+						},
+					}}),
+				)),
+			}},
+			want: &models.RemoteResources{Resources: []*models.RemoteResourceRef{
+				{
+					DeploymentID:       ec.String("first id"),
+					ElasticsearchRefID: ec.String("main-elasticsearch"),
+					Alias:              ec.String("caperucita"),
+				},
+				{
+					DeploymentID:       ec.String("second id"),
+					ElasticsearchRefID: ec.String("elasticsearch"),
+					Alias:              ec.String("bestest"),
+					SkipUnavailable:    ec.Bool(true),
+				},
+			}},
+		},
+		{
+			name: "succeeds with RefID discovery",
+			args: args{params: GetParams{
+				DeploymentID: mock.ValidClusterID,
+				API: api.NewMock(
+					mock.New200ResponseAssertion(
+						&mock.RequestAssertion{
+							Header: api.DefaultReadMockHeaders,
+							Method: "GET",
+							Host:   api.DefaultMockHost,
+							Path:   "/api/v1/deployments/320b7b540dfc967a7a649c18e2fce4ed",
+							Query: url.Values{
+								"convert_legacy_plans": {"false"},
+								"enrich_with_template": {"true"},
+								"show_metadata":        {"false"},
+								"show_plan_defaults":   {"false"},
+								"show_plan_history":    {"false"},
+								"show_plan_logs":       {"false"},
+								"show_plans":           {"false"},
+								"show_security":        {"false"},
+								"show_settings":        {"false"},
+								"show_system_alerts":   {"5"},
+							},
+						},
+						mock.NewStructBody(models.DeploymentGetResponse{
+							Healthy: ec.Bool(true),
+							ID:      ec.String(mock.ValidClusterID),
+							Resources: &models.DeploymentResources{
+								Elasticsearch: []*models.ElasticsearchResourceInfo{{
+									ID:    ec.String(mock.ValidClusterID),
+									RefID: ec.String("elasticsearch"),
+								}},
+							},
+						}),
+					),
+					mock.New200ResponseAssertion(
+						&mock.RequestAssertion{
+							Header: api.DefaultReadMockHeaders,
+							Method: "GET",
+							Host:   api.DefaultMockHost,
+							Path:   "/api/v1/deployments/320b7b540dfc967a7a649c18e2fce4ed/elasticsearch/elasticsearch/remote-clusters",
+						},
+						mock.NewStructBody(models.RemoteResources{Resources: []*models.RemoteResourceRef{
+							{
+								DeploymentID:       ec.String("first id"),
+								ElasticsearchRefID: ec.String("main-elasticsearch"),
+								Alias:              ec.String("caperucita"),
+								SkipUnavailable:    ec.Bool(true),
+							},
+							{
+								DeploymentID:       ec.String("second id"),
+								ElasticsearchRefID: ec.String("elasticsearch"),
+								Alias:              ec.String("bestest"),
+							},
+						}}),
+					),
+				),
+			}},
+			want: &models.RemoteResources{Resources: []*models.RemoteResourceRef{
+				{
+					DeploymentID:       ec.String("first id"),
+					ElasticsearchRefID: ec.String("main-elasticsearch"),
+					Alias:              ec.String("caperucita"),
+					SkipUnavailable:    ec.Bool(true),
+				},
+				{
+					DeploymentID:       ec.String("second id"),
+					ElasticsearchRefID: ec.String("elasticsearch"),
+					Alias:              ec.String("bestest"),
+				},
+			}},
+		},
+		{
+			name: "fails on RefID discovery",
+			args: args{params: GetParams{
+				DeploymentID: mock.ValidClusterID,
+				API: api.NewMock(
+					mock.New500ResponseAssertion(
+						&mock.RequestAssertion{
+							Header: api.DefaultReadMockHeaders,
+							Method: "GET",
+							Host:   api.DefaultMockHost,
+							Path:   "/api/v1/deployments/320b7b540dfc967a7a649c18e2fce4ed",
+							Query: url.Values{
+								"convert_legacy_plans": {"false"},
+								"enrich_with_template": {"true"},
+								"show_metadata":        {"false"},
+								"show_plan_defaults":   {"false"},
+								"show_plan_history":    {"false"},
+								"show_plan_logs":       {"false"},
+								"show_plans":           {"false"},
+								"show_security":        {"false"},
+								"show_settings":        {"false"},
+								"show_system_alerts":   {"5"},
+							},
+						},
+						mock.SampleInternalError().Response.Body,
+					),
+				),
+			}},
+			err: mock.MultierrorInternalError,
+		},
+		{
+			name: "fails on API error",
+			args: args{params: GetParams{
+				DeploymentID: mock.ValidClusterID,
+				RefID:        "main-elasticsearch",
+				API: api.NewMock(mock.New500ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/320b7b540dfc967a7a649c18e2fce4ed/elasticsearch/main-elasticsearch/remote-clusters",
+					},
+					mock.SampleInternalError().Response.Body,
+				)),
+			}},
+			err: mock.MultierrorInternalError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Get(tt.args.params)
+			if !assert.Equal(t, tt.err, err) {
+				t.Error(err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/api/deploymentapi/esremoteclustersapi/update_test.go
+++ b/pkg/api/deploymentapi/esremoteclustersapi/update_test.go
@@ -1,0 +1,196 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package esremoteclustersapi
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestUpdate(t *testing.T) {
+	successContents := models.RemoteResources{Resources: []*models.RemoteResourceRef{
+		{
+			DeploymentID:       ec.String("first id"),
+			ElasticsearchRefID: ec.String("main-elasticsearch"),
+			Alias:              ec.String("caperucita"),
+			SkipUnavailable:    ec.Bool(true),
+		},
+		{
+			DeploymentID:       ec.String("second id"),
+			ElasticsearchRefID: ec.String("elasticsearch"),
+			Alias:              ec.String("bestest"),
+		},
+	}}
+
+	rawBody, err := successContents.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawBody = append(rawBody, []byte("\n")...)
+	type args struct {
+		params UpdateParams
+	}
+	tests := []struct {
+		name string
+		args args
+		err  error
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid elasticsearch remote clusters api params",
+				apierror.ErrMissingAPI,
+				apierror.ErrDeploymentID,
+				errors.New("required remote resources not provided"),
+			),
+		},
+		{
+			name: "succeeds",
+			args: args{params: UpdateParams{
+				DeploymentID:    mock.ValidClusterID,
+				RefID:           "main-elasticsearch",
+				RemoteResources: &successContents,
+				API: api.NewMock(mock.New202ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "PUT",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/320b7b540dfc967a7a649c18e2fce4ed/elasticsearch/main-elasticsearch/remote-clusters",
+						Body:   mock.NewByteBody(rawBody),
+					},
+					mock.NewStringBody(`{}`),
+				)),
+			}},
+		},
+		{
+			name: "succeeds with RefID discovery",
+			args: args{params: UpdateParams{
+				DeploymentID:    mock.ValidClusterID,
+				RemoteResources: &successContents,
+				API: api.NewMock(
+					mock.New200ResponseAssertion(
+						&mock.RequestAssertion{
+							Header: api.DefaultReadMockHeaders,
+							Method: "GET",
+							Host:   api.DefaultMockHost,
+							Path:   "/api/v1/deployments/320b7b540dfc967a7a649c18e2fce4ed",
+							Query: url.Values{
+								"convert_legacy_plans": {"false"},
+								"enrich_with_template": {"true"},
+								"show_metadata":        {"false"},
+								"show_plan_defaults":   {"false"},
+								"show_plan_history":    {"false"},
+								"show_plan_logs":       {"false"},
+								"show_plans":           {"false"},
+								"show_security":        {"false"},
+								"show_settings":        {"false"},
+								"show_system_alerts":   {"5"},
+							},
+						},
+						mock.NewStructBody(models.DeploymentGetResponse{
+							Healthy: ec.Bool(true),
+							ID:      ec.String(mock.ValidClusterID),
+							Resources: &models.DeploymentResources{
+								Elasticsearch: []*models.ElasticsearchResourceInfo{{
+									ID:    ec.String(mock.ValidClusterID),
+									RefID: ec.String("elasticsearch"),
+								}},
+							},
+						}),
+					),
+					mock.New202ResponseAssertion(
+						&mock.RequestAssertion{
+							Header: api.DefaultWriteMockHeaders,
+							Method: "PUT",
+							Host:   api.DefaultMockHost,
+							Path:   "/api/v1/deployments/320b7b540dfc967a7a649c18e2fce4ed/elasticsearch/elasticsearch/remote-clusters",
+							Body:   mock.NewByteBody(rawBody),
+						},
+						mock.NewStringBody(`{}`),
+					),
+				),
+			}},
+		},
+		{
+			name: "fails on RefID discovery",
+			args: args{params: UpdateParams{
+				DeploymentID:    mock.ValidClusterID,
+				RemoteResources: new(models.RemoteResources),
+				API: api.NewMock(
+					mock.New500ResponseAssertion(
+						&mock.RequestAssertion{
+							Header: api.DefaultReadMockHeaders,
+							Method: "GET",
+							Host:   api.DefaultMockHost,
+							Path:   "/api/v1/deployments/320b7b540dfc967a7a649c18e2fce4ed",
+							Query: url.Values{
+								"convert_legacy_plans": {"false"},
+								"enrich_with_template": {"true"},
+								"show_metadata":        {"false"},
+								"show_plan_defaults":   {"false"},
+								"show_plan_history":    {"false"},
+								"show_plan_logs":       {"false"},
+								"show_plans":           {"false"},
+								"show_security":        {"false"},
+								"show_settings":        {"false"},
+								"show_system_alerts":   {"5"},
+							},
+						},
+						mock.SampleInternalError().Response.Body,
+					),
+				),
+			}},
+			err: mock.MultierrorInternalError,
+		},
+		{
+			name: "fails on API error",
+			args: args{params: UpdateParams{
+				DeploymentID:    mock.ValidClusterID,
+				RefID:           "main-elasticsearch",
+				RemoteResources: new(models.RemoteResources),
+				API: api.NewMock(mock.New500ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "PUT",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/320b7b540dfc967a7a649c18e2fce4ed/elasticsearch/main-elasticsearch/remote-clusters",
+						Body:   mock.NewStringBody(`{"resources":null}` + "\n"),
+					},
+					mock.SampleInternalError().Response.Body,
+				)),
+			}},
+			err: mock.MultierrorInternalError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Update(tt.args.params); !assert.Equal(t, tt.err, err) {
+				t.Error(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This patch adds both `Get()` and `Update()` functions for the remote
clusters APIs which power ESS Cross Cluster Search assignments.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Part of elastic/terraform-provider-ec#137

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add the `remote-clusters` APIs to the SDK.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
