### PR TITLE
transport: Fix retries logic when enabled

### DIFF
--- a/pkg/api/transport_custom_test.go
+++ b/pkg/api/transport_custom_test.go
@@ -27,10 +27,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewCustomTransport(t *testing.T) {
@@ -150,7 +149,7 @@ func TestCustomTransport_RoundTrip(t *testing.T) {
 			},
 			args:    args{req: req},
 			err:     context.DeadlineExceeded,
-			wantOut: "==================== Start of Request #1 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: mocked\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #1  ====================\nrequest 1/2 timed out, retrying...\n==================== Start of Request #2 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: mocked\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #2  ====================\nrequest 2/2 timed out, giving up.\n",
+			wantOut: "==================== Start of Request #1 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: mocked\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #1  ====================\nrequest timed out, retrying...\n==================== Start of Request #2 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: mocked\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #2  ====================\nrequest timed out, giving up.\n",
 		},
 		{
 			name: "returns a different error after the maximum retries have been reached",
@@ -178,7 +177,7 @@ func TestCustomTransport_RoundTrip(t *testing.T) {
 			},
 			args:    args{req: req},
 			err:     errors.New("some other error"),
-			wantOut: "==================== Start of Request #1 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: mocked\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #1  ====================\nrequest 1/2 timed out, retrying...\n==================== Start of Request #2 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: mocked\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #2  ====================\n",
+			wantOut: "==================== Start of Request #1 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: mocked\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #1  ====================\nrequest timed out, retrying...\n==================== Start of Request #2 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: mocked\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #2  ====================\n",
 		},
 		{
 			name: "succeeds after retrying the request",
@@ -202,7 +201,7 @@ func TestCustomTransport_RoundTrip(t *testing.T) {
 			want: &http.Response{
 				StatusCode: 200,
 			},
-			wantOut: "==================== Start of Request #1 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: mocked\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #1  ====================\nrequest 1/2 timed out, retrying...\n==================== Start of Request #2 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: mocked\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #2  ====================\n==================== Start of Response #2 ====================\nHTTP/0.0 200 OK\r\n\r\n{}\n====================  End of Response #2  ====================\n",
+			wantOut: "==================== Start of Request #1 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: mocked\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #1  ====================\nrequest timed out, retrying...\n==================== Start of Request #2 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: mocked\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #2  ====================\n==================== Start of Response #2 ====================\nHTTP/0.0 200 OK\r\n\r\n{}\n====================  End of Response #2  ====================\n",
 		},
 		{
 			name: "succeeds after retrying the request and redacts the Authorization header",
@@ -227,7 +226,77 @@ func TestCustomTransport_RoundTrip(t *testing.T) {
 			want: &http.Response{
 				StatusCode: 200,
 			},
-			wantOut: "==================== Start of Request #1 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: [REDACTED]\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #1  ====================\nrequest 1/2 timed out, retrying...\n==================== Start of Request #2 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: [REDACTED]\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #2  ====================\n==================== Start of Response #2 ====================\nHTTP/0.0 200 OK\r\nContent-Length: 0\r\n\r\n\n====================  End of Response #2  ====================\n",
+			wantOut: "==================== Start of Request #1 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: [REDACTED]\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #1  ====================\nrequest timed out, retrying...\n==================== Start of Request #2 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: [REDACTED]\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #2  ====================\n==================== Start of Response #2 ====================\nHTTP/0.0 200 OK\r\nContent-Length: 0\r\n\r\n\n====================  End of Response #2  ====================\n",
+		},
+		{
+			name: "succeeds after retrying the request and redacts the Authorization header",
+			fields: fields{
+				rt: mock.NewRoundTripper(
+					mock.Response{
+						Response: http.Response{
+							StatusCode: 500,
+							Body:       mock.NewStringBody("{}"),
+						},
+						Error: context.DeadlineExceeded,
+					},
+					mock.Response{
+						Response: http.Response{
+							StatusCode: 404,
+							Body:       mock.NewStringBody("{}"),
+						},
+						Error: context.DeadlineExceeded,
+					},
+					mock.New201Response(ioutil.NopCloser(sucessBuf)),
+				),
+				retries:    2,
+				verbose:    true,
+				redactAuth: true,
+				writer:     new(bytes.Buffer),
+				backoff:    time.Nanosecond,
+			},
+			args: args{req: req},
+			want: &http.Response{
+				StatusCode: 201,
+			},
+			wantOut: "==================== Start of Request #1 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: [REDACTED]\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #1  ====================\nrequest timed out, retrying...\n==================== Start of Request #2 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: [REDACTED]\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #2  ====================\nrequest timed out, retrying...\n==================== Start of Request #3 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: [REDACTED]\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #3  ====================\n==================== Start of Response #3 ====================\nHTTP/0.0 201 Created\r\nContent-Length: 0\r\n\r\n\n====================  End of Response #3  ====================\n",
+		},
+		{
+			name: "succeeds directly (Ensures that no retries are performed when err! = context.DeadlineExceeded)",
+			fields: fields{
+				rt: mock.NewRoundTripper(
+					mock.New202Response(ioutil.NopCloser(sucessBuf)),
+				),
+				retries:    2,
+				verbose:    true,
+				redactAuth: true,
+				writer:     new(bytes.Buffer),
+				backoff:    time.Nanosecond,
+			},
+			args: args{req: req},
+			want: &http.Response{
+				StatusCode: 202,
+			},
+			wantOut: "==================== Start of Request #1 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: [REDACTED]\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #1  ====================\n==================== Start of Response #1 ====================\nHTTP/0.0 202 Accepted\r\nContent-Length: 0\r\n\r\n\n====================  End of Response #1  ====================\n",
+		},
+		{
+			name: "fails directly (Ensures that no retries are performed when err! = context.DeadlineExceeded)",
+			fields: fields{
+				rt: mock.NewRoundTripper(mock.Response{
+					Response: http.Response{
+						StatusCode: 500,
+						Body:       mock.NewStringBody("{}"),
+					},
+					Error: context.Canceled,
+				}),
+				retries:    2,
+				verbose:    true,
+				redactAuth: true,
+				writer:     new(bytes.Buffer),
+				backoff:    time.Nanosecond,
+			},
+			args:    args{req: req},
+			wantOut: "==================== Start of Request #1 ====================\nmethod / HTTP/1.1\r\nHost: localhost\r\nAuthorization: [REDACTED]\r\nAccept-Encoding: gzip\r\n\r\n\n====================  End of Request #1  ====================\n",
+			err:     context.Canceled,
 		},
 	}
 	for _, tt := range tests {
@@ -253,6 +322,45 @@ func TestCustomTransport_RoundTrip(t *testing.T) {
 			if buf, ok := ct.writer.(*bytes.Buffer); ok {
 				assert.Equal(t, tt.wantOut, buf.String())
 			}
+		})
+	}
+}
+
+func Test_backoff(t *testing.T) {
+	type args struct {
+		d time.Duration
+	}
+	tests := []struct {
+		name string
+		args args
+		want time.Duration
+	}{
+		{
+			name: "second backoff",
+			args: args{d: time.Second},
+			want: time.Second,
+		},
+		{
+			name: "two second backoff",
+			args: args{d: 2 * time.Second},
+			want: 2 * time.Second,
+		},
+		{
+			name: "ten second backoff",
+			args: args{d: 10 * time.Second},
+			want: 10 * time.Second,
+		},
+		{
+			name: "millisecond backoff",
+			args: args{d: time.Millisecond},
+			want: time.Millisecond,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := backoff(tt.args.d)
+			assert.NotZero(t, got)
+			assert.LessOrEqual(t, int64(got), int64(tt.want))
 		})
 	}
 }

--- a/pkg/api/transport_custom_test.go
+++ b/pkg/api/transport_custom_test.go
@@ -27,9 +27,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNewCustomTransport(t *testing.T) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes a severe bug where the `*http.Response` and / or `error` from the
custom `http.RoundTripper` implementation were lost very often, causing
any clients with `retries > 0` to miss-behave, causing some http calls
to never return.

I've added a few tests to ensure this doesn't happen again and tested
very thoroughly with the terraform provider with both retries enabled,
and disabled.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Introduced by #220

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Terraform provider, with Retries from 0 to 4.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
