### PR TITLE
http: Retry on net.Error.Timeout() == true

### DIFF
--- a/pkg/api/transport_custom.go
+++ b/pkg/api/transport_custom.go
@@ -18,11 +18,11 @@
 package api
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"regexp"
@@ -149,7 +149,7 @@ func (t *CustomTransport) doRoundTrip(req *http.Request, retries int) (*http.Res
 		handleVerboseResponse(t.writer, res, count)
 	}
 
-	if errors.Is(err, context.DeadlineExceeded) {
+	if e, ok := err.(net.Error); ok && e.Timeout() {
 		if t.verbose {
 			msg := "request timed out, retrying..."
 			if retries <= 0 {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Modifies the error assertion on the custom `http.RoundTripper` to use
`net.Error` instead of the struct type `context.DeadlineExceeded`. This
allows the client retries to be performed un many more timeouts (net,
http, or sdk framework).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Retry on any timeout.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
