### PR TITLE
api: Correct all timeout values for retries

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -25,11 +25,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/auth"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
 	"github.com/elastic/cloud-sdk-go/pkg/output"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNewAPI(t *testing.T) {

--- a/pkg/api/transport_custom.go
+++ b/pkg/api/transport_custom.go
@@ -43,7 +43,7 @@ const userAgentHeader = "User-Agent"
 // It defaults to the project name + the current committed version.
 var DefaultUserAgent = "cloud-sdk-go/" + Version
 
-var defaultBackoff = time.Second * 1
+var defaultBackoff = time.Second
 
 // CustomTransport is the cloud-sdk-go custom transport which handles all the
 // add-ons for http request and responses. It supports:


### PR DESCRIPTION




<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
This patch takes into consideration all the Timeout values used on all
layers of the sdk, this means that we have to account for in order from
a nested view:

- `runtime.ClientTransport`: The auto-generated client transport has its
  own configurable timeout (per operation), which will also cancel any
  outgoing requests if the timeout is exceeded. When individual client
  requests do not include a Timeout configured, a default variable is
  used: `runtimeclient.DefaultTimeout`, which is why we're  modifying
  its value.
- `http.Client.Timeout`: Within the `http.Client` The timeout includes
  connection time, any redirects, and reading the response body.
- `net.Dialer.Timeout`: Within the `http.RoundTripper` implementation,
  this is the timeout that is used on a per-request basis.

Taking all the above cancellations into consideration the best way to
support the retries at the http.RoundTripper implementation level is:

- Set `http.Client.Timeout = 0`, since we have the cancellation set on
  the `runtime.ClientTransport`.
- Set the runtime timeout (`runtime.ClientTransport`) to the a computed
  timeout value which is: timeout * retries + (backoff * retries), to be
  able to factor in the total retry time in timeout.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By connecting my machine to a very slow network and getting so many timeouts.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)