### PR TITLE
deptemplateapi: Remove workaround for the deployment template get API

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,7 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -299,6 +300,7 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -529,6 +531,7 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/pkg/api/deploymentapi/depresourceapi/new_payload.go
+++ b/pkg/api/deploymentapi/depresourceapi/new_payload.go
@@ -57,9 +57,6 @@ type NewPayloadParams struct {
 	// Optionally enable an Enterprise Search instance.
 	EnterpriseSearchEnable bool
 
-	// Do not use. The field will be removed once an API bug has been resolved.
-	DeploymentTemplateAsList bool
-
 	// Optional io.Writer where notices will be written.
 	Writer io.Writer
 
@@ -95,7 +92,6 @@ func NewPayload(params NewPayloadParams) (*models.DeploymentCreateRequest, error
 		API:        params.API,
 		TemplateID: params.DeploymentTemplateID,
 		Region:     params.Region,
-		AsList:     params.DeploymentTemplateAsList,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/api/deploymentapi/depresourceapi/new_payload_test.go
+++ b/pkg/api/deploymentapi/depresourceapi/new_payload_test.go
@@ -397,11 +397,10 @@ func TestNewPayload(t *testing.T) {
 			}},
 		},
 		{
-			name: "Succeeds to create a deployment payload with ES and Kibana instances (AsList)",
+			name: "Succeeds to create a deployment payload with ES and Kibana instances",
 			args: args{params: NewPayloadParams{
-				Version:                  "7.6.1",
-				Region:                   "ece-region",
-				DeploymentTemplateAsList: true,
+				Version: "7.6.1",
+				Region:  "ece-region",
 				ElasticsearchInstance: InstanceParams{
 					RefID:     "main-elasticsearch",
 					Size:      1024,
@@ -414,7 +413,7 @@ func TestNewPayload(t *testing.T) {
 				},
 				DeploymentTemplateID: "default",
 				API: api.NewMock(
-					mock.New200Response(mock.NewStructBody([]models.DeploymentTemplateInfoV2{kibanaTemplateResponse})),
+					mock.New200Response(mock.NewStructBody(kibanaTemplateResponse)),
 				),
 			}},
 			want: &models.DeploymentCreateRequest{Resources: &models.DeploymentCreateResources{
@@ -486,97 +485,6 @@ func TestNewPayload(t *testing.T) {
 				ApmEnable:            true,
 				API: api.NewMock(
 					mock.New200Response(mock.NewStructBody(apmKibanaTemplateResponse)),
-				),
-			}},
-			want: &models.DeploymentCreateRequest{Resources: &models.DeploymentCreateResources{
-				Elasticsearch: []*models.ElasticsearchPayload{{
-					RefID:  ec.String("main-elasticsearch"),
-					Region: ec.String("ece-region"),
-					Plan: &models.ElasticsearchClusterPlan{
-						Elasticsearch: &models.ElasticsearchConfiguration{
-							Version: "7.6.1",
-						},
-						DeploymentTemplate: &models.DeploymentTemplateReference{
-							ID: ec.String("default"),
-						},
-						ClusterTopology: []*models.ElasticsearchClusterTopologyElement{{
-							ZoneCount:               1,
-							InstanceConfigurationID: "default.data",
-							Size: &models.TopologySize{
-								Resource: ec.String("memory"),
-								Value:    ec.Int32(1024),
-							},
-							NodeType: &models.ElasticsearchNodeType{
-								Data: ec.Bool(true),
-							},
-						}},
-					}},
-				},
-				Kibana: []*models.KibanaPayload{{
-					ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
-					Region:                    ec.String("ece-region"),
-					RefID:                     ec.String("main-kibana"),
-					Plan: &models.KibanaClusterPlan{
-						Kibana: &models.KibanaConfiguration{
-							Version: "7.6.1",
-						},
-						ClusterTopology: []*models.KibanaClusterTopologyElement{
-							{
-								Size: &models.TopologySize{
-									Resource: ec.String("memory"),
-									Value:    ec.Int32(1024),
-								},
-								ZoneCount: 1,
-							},
-						},
-					},
-				}},
-				Apm: []*models.ApmPayload{{
-					ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
-					Region:                    ec.String("ece-region"),
-					RefID:                     ec.String("main-apm"),
-					Plan: &models.ApmPlan{
-						Apm: &models.ApmConfiguration{
-							Version: "7.6.1",
-						},
-						ClusterTopology: []*models.ApmTopologyElement{
-							{
-								Size: &models.TopologySize{
-									Resource: ec.String("memory"),
-									Value:    ec.Int32(1024),
-								},
-								ZoneCount: 1,
-							},
-						},
-					},
-				}},
-			}},
-		},
-		{
-			name: "Succeeds to create a deployment payload with ES, Kibana and APM instances (AsList)",
-			args: args{params: NewPayloadParams{
-				Version:                  "7.6.1",
-				Region:                   "ece-region",
-				DeploymentTemplateAsList: true,
-				ElasticsearchInstance: InstanceParams{
-					RefID:     "main-elasticsearch",
-					Size:      1024,
-					ZoneCount: 1,
-				},
-				KibanaInstance: InstanceParams{
-					RefID:     "main-kibana",
-					Size:      1024,
-					ZoneCount: 1,
-				},
-				ApmInstance: InstanceParams{
-					RefID:     "main-apm",
-					Size:      1024,
-					ZoneCount: 1,
-				},
-				DeploymentTemplateID: "default",
-				ApmEnable:            true,
-				API: api.NewMock(
-					mock.New200Response(mock.NewStructBody([]models.DeploymentTemplateInfoV2{apmKibanaTemplateResponse})),
 				),
 			}},
 			want: &models.DeploymentCreateRequest{Resources: &models.DeploymentCreateResources{

--- a/pkg/api/deploymentapi/deptemplateapi/get.go
+++ b/pkg/api/deploymentapi/deptemplateapi/get.go
@@ -19,7 +19,6 @@ package deptemplateapi
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
@@ -38,9 +37,6 @@ type GetParams struct {
 	StackVersion string
 
 	HideInstanceConfigurations bool
-
-	// This field will be removed once a public API bug has been resolved
-	AsList bool
 }
 
 // Validate ensures the parameters are usable by Get.
@@ -72,27 +68,6 @@ func Get(params GetParams) (*models.DeploymentTemplateInfoV2, error) {
 }
 
 func get(params GetParams) (*models.DeploymentTemplateInfoV2, error) {
-	// Temporary workaround for an existing API bug.
-	if params.AsList {
-		res, err := List(ListParams{
-			API:                        params.API,
-			StackVersion:               params.StackVersion,
-			Region:                     params.Region,
-			HideInstanceConfigurations: params.HideInstanceConfigurations,
-		})
-		if err != nil {
-			return nil, err
-		}
-		for _, t := range res {
-			if params.TemplateID == *t.ID {
-				return t, nil
-			}
-		}
-		return nil, multierror.NewPrefixed("failed obtaining deployment template",
-			fmt.Errorf(`deployment template "%s" cannot be found`, params.TemplateID),
-		)
-	}
-
 	res, err := params.V1API.DeploymentTemplates.GetDeploymentTemplateV2(
 		getParams(params), params.AuthWriter,
 	)

--- a/pkg/api/deploymentapi/deptemplateapi/get_test.go
+++ b/pkg/api/deploymentapi/deptemplateapi/get_test.go
@@ -115,54 +115,6 @@ func TestGet(t *testing.T) {
 			want: succeedResp,
 		},
 		{
-			name: "succeeds when AsList is set to true",
-			args: args{params: GetParams{
-				Region:     "us-east-1",
-				TemplateID: "default",
-				AsList:     true,
-				API: api.NewMock(mock.New200ResponseAssertion(
-					&mock.RequestAssertion{
-						Header: api.DefaultReadMockHeaders,
-						Method: "GET",
-						Host:   api.DefaultMockHost,
-						Path:   "/api/v1/deployments/templates",
-						Query: url.Values{
-							"region":                       []string{"us-east-1"},
-							"show_hidden":                  []string{"false"},
-							"show_instance_configurations": []string{"true"},
-						},
-					},
-					mock.NewByteBody(listRawResp),
-				)),
-			}},
-			want: succeedResp,
-		},
-		{
-			name: "fails when AsList is set to true and deployment template cannot be found",
-			args: args{params: GetParams{
-				Region:     "us-east-1",
-				TemplateID: "some-other-template",
-				AsList:     true,
-				API: api.NewMock(mock.New200ResponseAssertion(
-					&mock.RequestAssertion{
-						Header: api.DefaultReadMockHeaders,
-						Method: "GET",
-						Host:   api.DefaultMockHost,
-						Path:   "/api/v1/deployments/templates",
-						Query: url.Values{
-							"region":                       []string{"us-east-1"},
-							"show_hidden":                  []string{"false"},
-							"show_instance_configurations": []string{"true"},
-						},
-					},
-					mock.NewByteBody(listRawResp),
-				)),
-			}},
-			err: multierror.NewPrefixed("failed obtaining deployment template",
-				errors.New(`deployment template "some-other-template" cannot be found`),
-			),
-		},
-		{
 			name: "fails on API error",
 			args: args{params: GetParams{
 				Region:     "us-east-1",
@@ -175,29 +127,6 @@ func TestGet(t *testing.T) {
 						Path:   "/api/v1/deployments/templates/some-id",
 						Query: url.Values{
 							"region":                       []string{"us-east-1"},
-							"show_instance_configurations": []string{"true"},
-						},
-					},
-					mock.SampleInternalError().Response.Body,
-				)),
-			}},
-			err: mock.MultierrorInternalError,
-		},
-		{
-			name: "returns error when List returns error",
-			args: args{params: GetParams{
-				Region:     "us-east-1",
-				TemplateID: "some-id",
-				AsList:     true,
-				API: api.NewMock(mock.New500ResponseAssertion(
-					&mock.RequestAssertion{
-						Header: api.DefaultReadMockHeaders,
-						Method: "GET",
-						Host:   api.DefaultMockHost,
-						Path:   "/api/v1/deployments/templates",
-						Query: url.Values{
-							"region":                       []string{"us-east-1"},
-							"show_hidden":                  []string{"false"},
 							"show_instance_configurations": []string{"true"},
 						},
 					},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
As the bug with the GET deployments/template/{template_id} endpoint
has been fixed, we no longer need to use the `AsList` field when calling it.

## Motivation and Context
Stay updated!

## How Has This Been Tested?
Manually by faking the SDK in ecctl and the TF provider

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Refactoring (improves code quality but has no user-facing effect)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
