### PR TITLE
deploymentapi: New Migrate API for the deployment migrate endpoint

### DIFF
--- a/pkg/api/deploymentapi/migrate.go
+++ b/pkg/api/deploymentapi/migrate.go
@@ -1,0 +1,73 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deploymentapi
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// MigrateParams is consumed by Migrate.
+type MigrateParams struct {
+	*api.API
+
+	DeploymentID string
+	TemplateID   string
+}
+
+// Validate ensures the parameters are usable by Migrate.
+func (params MigrateParams) Validate() error {
+	var merr = multierror.NewPrefixed("deployment migrate")
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	if len(params.DeploymentID) != 32 {
+		merr = merr.Append(apierror.ErrDeploymentID)
+	}
+
+	if params.TemplateID == "" {
+		merr = merr.Append(errors.New("a target deployment template is necessary for this operation"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Migrate returns a deployment update request that would transform this deployment from its template to the provided one.
+func Migrate(params MigrateParams) (*models.DeploymentTemplateMigrateResponse, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.V1API.Deployments.MigrateDeployment(
+		deployments.NewMigrateDeploymentParams().
+			WithDeploymentID(params.DeploymentID).
+			WithTemplate(params.TemplateID),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, apierror.Unwrap(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/api/deploymentapi/migrate_test.go
+++ b/pkg/api/deploymentapi/migrate_test.go
@@ -1,0 +1,121 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package deploymentapi
+
+import (
+	"errors"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestMigrate(t *testing.T) {
+	type args struct {
+		params MigrateParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.DeploymentTemplateMigrateResponse
+		err  error
+	}{
+		{
+			name: "fails on parameter validation",
+			err: multierror.NewPrefixed("deployment migrate",
+				apierror.ErrMissingAPI,
+				apierror.ErrDeploymentID,
+				errors.New("a target deployment template is necessary for this operation"),
+			),
+		},
+		{
+			name: "fails on API error",
+			args: args{params: MigrateParams{
+				API:          api.NewMock(mock.New500Response(mock.NewStringBody(`{"error": "some error"}`))),
+				DeploymentID: mock.ValidClusterID,
+				TemplateID:   "aws-io-optimized",
+			}},
+			err: errors.New(`{"error": "some error"}`),
+		},
+		{
+			name: "Succeeds",
+			args: args{params: MigrateParams{
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "POST",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/320b7b540dfc967a7a649c18e2fce4ed/_migrate",
+						Query: url.Values{
+							"template": {"aws-io-optimized"},
+						},
+					},
+					mock.NewStructBody(models.DeploymentTemplateMigrateResponse{
+						Resources: &models.DeploymentUpdateRequest{
+							Resources: &models.DeploymentUpdateResources{
+								Elasticsearch: []*models.ElasticsearchPayload{
+									{
+										Plan: &models.ElasticsearchClusterPlan{
+											DeploymentTemplate: &models.DeploymentTemplateReference{
+												ID: ec.String("aws-io-optimized"),
+											},
+										},
+									},
+								},
+							},
+						},
+					}))),
+				DeploymentID: mock.ValidClusterID,
+				TemplateID:   "aws-io-optimized",
+			}},
+			want: &models.DeploymentTemplateMigrateResponse{
+				Resources: &models.DeploymentUpdateRequest{
+					Resources: &models.DeploymentUpdateResources{
+						Elasticsearch: []*models.ElasticsearchPayload{
+							{
+								Plan: &models.ElasticsearchClusterPlan{
+									DeploymentTemplate: &models.DeploymentTemplateReference{
+										ID: ec.String("aws-io-optimized"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Migrate(tt.args.params)
+			if !reflect.DeepEqual(err, tt.err) {
+				t.Errorf("Migrate() error = %v, wantErr %v", err, tt.err)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Migrate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Adds a new `Migrate` API to the `deploymentapi` package.
This new API returns a deployment update request that would 
transform this deployment from its template to the provided one.

## Related Issues
Part of https://github.com/elastic/terraform-provider-ec/issues/157

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
