### PR TITLE
adds a function to create an int pointer from an int

### DIFF
--- a/pkg/util/ec/types.go
+++ b/pkg/util/ec/types.go
@@ -43,6 +43,9 @@ func Int32(i int32) *int32 { return &i }
 // Int64 creates a new int64 pointer from an int64
 func Int64(i int64) *int64 { return &i }
 
+// Int creates a new int pointer from an int
+func Int(i int) *int { return &i }
+
 // CompareStructs two structs and return the differences
 func CompareStructs(a, b interface{}) (equals bool, diff string, err error) {
 	var spewConfig = spew.ConfigState{

--- a/pkg/util/ec/types_test.go
+++ b/pkg/util/ec/types_test.go
@@ -1,0 +1,45 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ec
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInt(t *testing.T) {
+	aNumber := rand.Int()
+	tests := []struct {
+		name     string
+		number   int
+		expected *int
+	}{
+		{
+			name:     "creates an int pointer",
+			number:   aNumber,
+			expected: &aNumber,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, Int(tt.number), tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Adds a function to create an int pointer from an int

## Related Issues
Required by https://github.com/elastic/cloud-cli/issues/1271

## Motivation and Context
During container set migration from v0 to v1 we need to create a pointer from an int

