### PR TITLE
adds map dereference function

### DIFF
--- a/pkg/util/maps/map.go
+++ b/pkg/util/maps/map.go
@@ -74,3 +74,23 @@ func HasKey(m map[string]interface{}, key string) bool {
 	_, ok := m[key]
 	return ok
 }
+
+// Dereference accepts a pointer to a string map of interface and returns the de-referenced value
+// as a string map of strings
+// if the input is nil or not supported then it returns an empty string map
+func Dereference(s interface{}) map[string]string {
+	switch m := s.(type) {
+	case *map[string]interface{}:
+		if m != nil {
+			newMap := make(map[string]string, len(*m))
+			for k, v := range *m {
+				newMap[k] = v.(string)
+			}
+			return newMap
+		}
+	default:
+		return make(map[string]string)
+	}
+
+	return make(map[string]string)
+}

--- a/pkg/util/maps/map_test.go
+++ b/pkg/util/maps/map_test.go
@@ -20,6 +20,8 @@ package maps
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/cloud-sdk-go/pkg/util/slice"
@@ -147,6 +149,50 @@ func TestFilter(t *testing.T) {
 					t.Errorf("Filter() result should have key = %v, but it hasn't", e)
 				}
 			}
+		})
+	}
+}
+
+func TestDereference(t *testing.T) {
+	type args struct {
+		input interface{}
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected map[string]string
+	}{
+		{
+			name: "should return an empty slice when input is nil",
+			args: args{
+				input: nil,
+			},
+			expected: make(map[string]string),
+		},
+		{
+			name: "should return an empty slice when input is not supported",
+			args: args{
+				input: []int{},
+			},
+			expected: make(map[string]string),
+		},
+		{
+			name: "should return the expected slice when input is a reference to string map of interfaces",
+			args: args{
+				input: &map[string]interface{}{
+					"1": "some-value-1",
+					"2": "some-value-2",
+				},
+			},
+			expected: map[string]string{
+				"1": "some-value-1",
+				"2": "some-value-2",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, Dereference(tt.args.input), tt.expected)
 		})
 	}
 }


### PR DESCRIPTION
## Description
Adds a map dereference function that accepts a pointer to a string map of interface and returns the de-referenced value as a string map of strings
if the input is nil or not supported then it returns an empty string map

## Related Issues
Required by https://github.com/elastic/cloud-cli/issues/1271


