### PR TITLE
deploymentapi: Fix update payload

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -431,6 +431,7 @@ go.mongodb.org/mongo-driver v1.3.4 h1:zs/dKNwX0gYUtzwrN9lLiR15hCO0nDwQj5xXx+vjCd
 go.mongodb.org/mongo-driver v1.3.4/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
 go.mongodb.org/mongo-driver v1.4.3 h1:moga+uhicpVshTyaqY9L23E6QqwcHRUv1sqyOsoyOO8=
 go.mongodb.org/mongo-driver v1.4.3/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
+go.mongodb.org/mongo-driver v1.4.4 h1:bsPHfODES+/yx2PCWzUYMH8xj6PVniPI8DQrsJuSXSs=
 go.mongodb.org/mongo-driver v1.4.4/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -491,6 +492,7 @@ golang.org/x/net v0.0.0-20200602114024-627f9648deb9 h1:pNX+40auqi2JqRfOP1akLGtYc
 golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb h1:eBmm0M9fYhWpKZLjQUUKka/LtIxf46G4fxeEz5KJr9U=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/pkg/api/deploymentapi/testdata/observability_get.json
+++ b/pkg/api/deploymentapi/testdata/observability_get.json
@@ -124,6 +124,16 @@
                                             "value": 0
                                         },
                                         "zone_count": 3
+                                    },
+                                    {
+                                        "elasticsearch": {},
+                                        "instance_configuration_id": "gcp.data.highio.1",
+                                        "node_type": {
+                                            "data": true,
+                                            "ingest": true,
+                                            "master": true
+                                        },
+                                        "zone_count": 1
                                     }
                                 ],
                                 "deployment_template": {

--- a/pkg/api/deploymentapi/update_payload.go
+++ b/pkg/api/deploymentapi/update_payload.go
@@ -97,7 +97,7 @@ func parseElasticsearchGetResponse(r *models.ElasticsearchResourceInfo) (payload
 
 	var ct = make([]*models.ElasticsearchClusterTopologyElement, 0, len(plan.Plan.ClusterTopology))
 	for _, t := range plan.Plan.ClusterTopology {
-		if t.Size.Value != nil && *t.Size.Value > 0 {
+		if t.Size != nil && t.Size.Value != nil && *t.Size.Value > 0 {
 			ct = append(ct, t)
 		}
 	}
@@ -124,7 +124,7 @@ func parseKibanaGetResponse(r *models.KibanaResourceInfo, esRefID string) *model
 
 	var ct = make([]*models.KibanaClusterTopologyElement, 0, len(plan.Plan.ClusterTopology))
 	for _, t := range plan.Plan.ClusterTopology {
-		if t.Size.Value != nil && *t.Size.Value > 0 {
+		if t.Size != nil && t.Size.Value != nil && *t.Size.Value > 0 {
 			ct = append(ct, t)
 		}
 	}
@@ -152,7 +152,7 @@ func parseApmGetResponse(r *models.ApmResourceInfo, esRefID string) *models.ApmP
 
 	var ct = make([]*models.ApmTopologyElement, 0, len(plan.Plan.ClusterTopology))
 	for _, t := range plan.Plan.ClusterTopology {
-		if t.Size.Value != nil && *t.Size.Value > 0 {
+		if t.Size != nil && t.Size.Value != nil && *t.Size.Value > 0 {
 			ct = append(ct, t)
 		}
 	}
@@ -180,7 +180,7 @@ func parseAppSearchGetResponse(r *models.AppSearchResourceInfo, esRefID string) 
 
 	var ct = make([]*models.AppSearchTopologyElement, 0, len(plan.Plan.ClusterTopology))
 	for _, t := range plan.Plan.ClusterTopology {
-		if t.Size.Value != nil && *t.Size.Value > 0 {
+		if t.Size != nil && t.Size.Value != nil && *t.Size.Value > 0 {
 			ct = append(ct, t)
 		}
 	}
@@ -208,7 +208,7 @@ func parseEnterpriseSearchGetResponse(r *models.EnterpriseSearchResourceInfo, es
 
 	var ct = make([]*models.EnterpriseSearchTopologyElement, 0, len(plan.Plan.ClusterTopology))
 	for _, t := range plan.Plan.ClusterTopology {
-		if t.Size.Value != nil && *t.Size.Value > 0 {
+		if t.Size != nil && t.Size.Value != nil && *t.Size.Value > 0 {
 			ct = append(ct, t)
 		}
 	}

--- a/pkg/api/deploymentapi/update_payload_test.go
+++ b/pkg/api/deploymentapi/update_payload_test.go
@@ -102,7 +102,7 @@ func TestNewUpdateRequest(t *testing.T) {
 			want: enterpriseSearchWant,
 		},
 		{
-			name: "parses a get response from a deployment with observability settings",
+			name: "parses a get response from a deployment with observability settings and empty size",
 			args: args{res: observabilityGet},
 			want: observabilityWant,
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes an issue where when generating a `DeploymentUpdateRequest` an 
empty `size` within a cluster topology element would cause a panic.

## Related Issues
Part of: https://github.com/elastic/ecctl/issues/413

## How Has This Been Tested?
Unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
