### PR TITLE
deploymentapi: Add new CRUD APIs for extensions

### DIFF
--- a/pkg/api/deploymentapi/extensionapi/create.go
+++ b/pkg/api/deploymentapi/extensionapi/create.go
@@ -1,0 +1,89 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package extensionapi
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/extensions"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// CreateParams is consumed by the Create function.
+type CreateParams struct {
+	*api.API
+
+	Name        string
+	Version     string
+	Type        string
+	DownloadURL string
+	Description string
+}
+
+// Validate ensures the parameters are usable by Create.
+func (params CreateParams) Validate() error {
+	var merr = multierror.NewPrefixed("invalid extension create params")
+
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	if params.Type == "" {
+		merr = merr.Append(errors.New("an extension type is required for this operation"))
+	}
+
+	if params.DownloadURL != "" {
+		_, err := url.ParseRequestURI(params.DownloadURL)
+		if err != nil {
+			merr = merr.Append(fmt.Errorf("the provided URL is invalid: %v", err))
+		}
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Create creates a new extension.
+func Create(params CreateParams) (*models.Extension, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	body := models.CreateExtensionRequest{
+		Description:   params.Description,
+		DownloadURL:   params.DownloadURL,
+		ExtensionType: &params.Type,
+		Name:          &params.Name,
+		Version:       &params.Version,
+	}
+
+	res, err := params.V1API.Extensions.CreateExtension(
+		extensions.NewCreateExtensionParams().
+			WithBody(&body),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, apierror.Wrap(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/api/deploymentapi/extensionapi/create_test.go
+++ b/pkg/api/deploymentapi/extensionapi/create_test.go
@@ -1,0 +1,110 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package extensionapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestCreate(t *testing.T) {
+	type args struct {
+		params CreateParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.Extension
+		err  string
+	}{
+		{
+			name: "fails due to parameter validation",
+			args: args{params: CreateParams{
+				DownloadURL: "imaurl",
+			}},
+			err: multierror.NewPrefixed("invalid extension create params",
+				apierror.ErrMissingAPI,
+				errors.New("an extension type is required for this operation"),
+				errors.New(`the provided URL is invalid: parse "imaurl": invalid URI for request`),
+			).Error(),
+		},
+		{
+			name: "succeeds",
+			args: args{params: CreateParams{
+				Name:        "Boop",
+				Version:     "v1.0",
+				Type:        "sometype",
+				DownloadURL: "https://www.example.com",
+				Description: "Why hello there",
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "POST",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/extensions",
+						Body:   mock.NewStringBody(`{"description":"Why hello there","download_url":"https://www.example.com","extension_type":"sometype","name":"Boop","version":"v1.0"}` + "\n"),
+					},
+					mock.NewStructBody(models.Extension{
+						ID:            ec.String("someid"),
+						Name:          ec.String("Boop"),
+						Version:       ec.String("v1.0"),
+						ExtensionType: ec.String("sometype"),
+						DownloadURL:   "https://www.example.com",
+						Description:   "Why hello there",
+					}),
+				)),
+			}},
+			err: `{"deployments":null,"description":"Why hello there","download_url":"https://www.example.com","extension_type":"sometype","id":"someid","name":"Boop","url":null,"version":"v1.0"}` + "\n",
+		},
+		{
+			name: "fails on API error",
+			args: args{params: CreateParams{
+				Type: "sometype",
+				API: api.NewMock(mock.New500ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "POST",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/extensions",
+						Body:   mock.NewStringBody(`{"extension_type":"sometype","name":"","version":""}` + "\n"),
+					},
+					mock.SampleInternalError().Response.Body,
+				)),
+			}},
+			err: mock.MultierrorInternalError.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Create(tt.args.params)
+			if err != nil && !assert.EqualError(t, err, tt.err) {
+				t.Error(err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/api/deploymentapi/extensionapi/create_test.go
+++ b/pkg/api/deploymentapi/extensionapi/create_test.go
@@ -81,6 +81,32 @@ func TestCreate(t *testing.T) {
 			err: `{"deployments":null,"description":"Why hello there","download_url":"https://www.example.com","extension_type":"sometype","id":"someid","name":"Boop","url":null,"version":"v1.0"}` + "\n",
 		},
 		{
+			name: "succeeds without download URL",
+			args: args{params: CreateParams{
+				Name:        "Boop",
+				Version:     "v1.0",
+				Type:        "sometype",
+				Description: "Why hello there",
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "POST",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/extensions",
+						Body:   mock.NewStringBody(`{"description":"Why hello there","extension_type":"sometype","name":"Boop","version":"v1.0"}` + "\n"),
+					},
+					mock.NewStructBody(models.Extension{
+						ID:            ec.String("someid"),
+						Name:          ec.String("Boop"),
+						Version:       ec.String("v1.0"),
+						ExtensionType: ec.String("sometype"),
+						Description:   "Why hello there",
+					}),
+				)),
+			}},
+			err: `{"deployments":null,"description":"Why hello there","extension_type":"sometype","id":"someid","name":"Boop","url":null,"version":"v1.0"}` + "\n",
+		},
+		{
 			name: "fails on API error",
 			args: args{params: CreateParams{
 				Type: "sometype",

--- a/pkg/api/deploymentapi/extensionapi/delete.go
+++ b/pkg/api/deploymentapi/extensionapi/delete.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package extensionapi
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/extensions"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// DeleteParams is consumed by the Delete function.
+type DeleteParams struct {
+	*api.API
+
+	ExtensionID string
+}
+
+// Validate ensures the parameters are usable by Delete.
+func (params DeleteParams) Validate() error {
+	var merr = multierror.NewPrefixed("invalid extension delete params")
+
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	if params.ExtensionID == "" {
+		merr = merr.Append(errors.New("an extension ID is required for this operation"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Delete deletes an extension.
+func Delete(params DeleteParams) error {
+	if err := params.Validate(); err != nil {
+		return err
+	}
+
+	_, err := params.V1API.Extensions.DeleteExtension(
+		extensions.NewDeleteExtensionParams().
+			WithExtensionID(params.ExtensionID),
+		params.AuthWriter,
+	)
+
+	return apierror.Wrap(err)
+}

--- a/pkg/api/deploymentapi/extensionapi/delete_test.go
+++ b/pkg/api/deploymentapi/extensionapi/delete_test.go
@@ -1,0 +1,92 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package extensionapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestDelete(t *testing.T) {
+	type args struct {
+		params DeleteParams
+	}
+	tests := []struct {
+		name string
+		args args
+		err  string
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid extension delete params",
+				apierror.ErrMissingAPI,
+				errors.New("an extension ID is required for this operation"),
+			).Error(),
+		},
+		{
+			name: "succeeds",
+			args: args{params: DeleteParams{
+				ExtensionID: "someid",
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "DELETE",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/extensions/someid",
+					},
+					mock.NewStructBody(models.Extension{
+						ID: ec.String("someid"),
+					}),
+				)),
+			}},
+		},
+		{
+			name: "fails on API error",
+			args: args{params: DeleteParams{
+				ExtensionID: "someid",
+				API: api.NewMock(mock.New500ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "DELETE",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/extensions/someid",
+					},
+					mock.SampleInternalError().Response.Body,
+				)),
+			}},
+			err: mock.MultierrorInternalError.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Delete(tt.args.params)
+			if err != nil && !assert.EqualError(t, err, tt.err) {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/api/deploymentapi/extensionapi/get.go
+++ b/pkg/api/deploymentapi/extensionapi/get.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package extensionapi
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/extensions"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+// GetParams is consumed by the Get function.
+type GetParams struct {
+	*api.API
+
+	ExtensionID        string
+	IncludeDeployments bool
+}
+
+// Validate ensures the parameters are usable by Get.
+func (params GetParams) Validate() error {
+	var merr = multierror.NewPrefixed("invalid extension get params")
+
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	if params.ExtensionID == "" {
+		merr = merr.Append(errors.New("an extension ID is required for this operation"))
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Get returns the specified extension.
+func Get(params GetParams) (*models.Extension, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.V1API.Extensions.GetExtension(
+		extensions.NewGetExtensionParams().
+			WithExtensionID(params.ExtensionID).
+			WithIncludeDeployments(ec.Bool(params.IncludeDeployments)),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, apierror.Wrap(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/api/deploymentapi/extensionapi/get_test.go
+++ b/pkg/api/deploymentapi/extensionapi/get_test.go
@@ -1,0 +1,101 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package extensionapi
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestGet(t *testing.T) {
+	type args struct {
+		params GetParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.Extension
+		err  string
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid extension get params",
+				apierror.ErrMissingAPI,
+				errors.New("an extension ID is required for this operation"),
+			).Error(),
+		},
+		{
+			name: "succeeds",
+			args: args{params: GetParams{
+				ExtensionID:        "someid",
+				IncludeDeployments: true,
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/extensions/someid",
+						Query:  url.Values{"include_deployments": {"true"}},
+					},
+					mock.NewStructBody(models.Extension{
+						ID: ec.String("someid"),
+					}),
+				)),
+			}},
+			want: &models.Extension{
+				ID: ec.String("someid"),
+			},
+		},
+		{
+			name: "fails on API error",
+			args: args{params: GetParams{
+				ExtensionID: "someid",
+				API: api.NewMock(mock.New500ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/extensions/someid",
+						Query:  url.Values{"include_deployments": {"false"}},
+					},
+					mock.SampleInternalError().Response.Body,
+				)),
+			}},
+			err: mock.MultierrorInternalError.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Get(tt.args.params)
+			if err != nil && !assert.EqualError(t, err, tt.err) {
+				t.Error(err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/api/deploymentapi/extensionapi/list.go
+++ b/pkg/api/deploymentapi/extensionapi/list.go
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package extensionapi
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/extensions"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// ListParams is consumed by the List function.
+type ListParams struct {
+	*api.API
+}
+
+// Validate ensures the parameters are usable by List.
+func (params ListParams) Validate() error {
+	var merr = multierror.NewPrefixed("invalid extension list params")
+
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// List returns a list of extensions.
+func List(params ListParams) (*models.Extensions, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	res, err := params.V1API.Extensions.ListExtensions(
+		extensions.NewListExtensionsParams(),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, apierror.Wrap(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/api/deploymentapi/extensionapi/list_test.go
+++ b/pkg/api/deploymentapi/extensionapi/list_test.go
@@ -1,0 +1,95 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package extensionapi
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+func TestList(t *testing.T) {
+	type args struct {
+		params ListParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.Extensions
+		err  string
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid extension list params",
+				apierror.ErrMissingAPI,
+			).Error(),
+		},
+		{
+			name: "succeeds",
+			args: args{params: ListParams{
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/extensions",
+						Query:  url.Values{"include_deployments": {"false"}},
+					},
+					mock.NewStructBody(models.Extensions{
+						Extensions: []*models.Extension{},
+					}),
+				)),
+			}},
+			want: &models.Extensions{
+				Extensions: []*models.Extension{},
+			},
+		},
+		{
+			name: "fails on API error",
+			args: args{params: ListParams{
+				API: api.NewMock(mock.New500ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultReadMockHeaders,
+						Method: "GET",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/extensions",
+						Query:  url.Values{"include_deployments": {"false"}},
+					},
+					mock.SampleInternalError().Response.Body,
+				)),
+			}},
+			err: mock.MultierrorInternalError.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := List(tt.args.params)
+			if err != nil && !assert.EqualError(t, err, tt.err) {
+				t.Error(err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/api/deploymentapi/extensionapi/update.go
+++ b/pkg/api/deploymentapi/extensionapi/update.go
@@ -1,0 +1,95 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package extensionapi
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/extensions"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+)
+
+// UpdateParams is consumed by the Update function.
+type UpdateParams struct {
+	*api.API
+
+	ExtensionID string
+	Name        string
+	Version     string
+	Type        string
+	DownloadURL string
+	Description string
+}
+
+// Validate ensures the parameters are usable by Update.
+func (params UpdateParams) Validate() error {
+	var merr = multierror.NewPrefixed("invalid extension update params")
+
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
+
+	if params.ExtensionID == "" {
+		merr = merr.Append(errors.New("an extension ID is required for this operation"))
+	}
+
+	if params.Type == "" {
+		merr = merr.Append(errors.New("an extension type is required for this operation"))
+	}
+
+	if params.DownloadURL != "" {
+		_, err := url.ParseRequestURI(params.DownloadURL)
+		if err != nil {
+			merr = merr.Append(fmt.Errorf("the provided URL is invalid: %v", err))
+		}
+	}
+
+	return merr.ErrorOrNil()
+}
+
+// Update updates the specified extension.
+func Update(params UpdateParams) (*models.Extension, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
+	body := models.UpdateExtensionRequest{
+		Description:   params.Description,
+		DownloadURL:   params.DownloadURL,
+		ExtensionType: &params.Type,
+		Name:          &params.Name,
+		Version:       &params.Version,
+	}
+
+	res, err := params.V1API.Extensions.UpdateExtension(
+		extensions.NewUpdateExtensionParams().
+			WithExtensionID(params.ExtensionID).
+			WithBody(&body),
+		params.AuthWriter,
+	)
+	if err != nil {
+		return nil, apierror.Wrap(err)
+	}
+
+	return res.Payload, nil
+}

--- a/pkg/api/deploymentapi/extensionapi/update_test.go
+++ b/pkg/api/deploymentapi/extensionapi/update_test.go
@@ -1,0 +1,120 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package extensionapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestUpdate(t *testing.T) {
+	type args struct {
+		params UpdateParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.Extension
+		err  string
+	}{
+		{
+			name: "fails due to parameter validation",
+			args: args{params: UpdateParams{
+				DownloadURL: "imaurl",
+			}},
+			err: multierror.NewPrefixed("invalid extension update params",
+				apierror.ErrMissingAPI,
+				errors.New("an extension ID is required for this operation"),
+				errors.New("an extension type is required for this operation"),
+				errors.New(`the provided URL is invalid: parse "imaurl": invalid URI for request`),
+			).Error(),
+		},
+		{
+			name: "succeeds",
+			args: args{params: UpdateParams{
+				ExtensionID: "someid",
+				Name:        "Boop",
+				Version:     "v1.0",
+				Type:        "sometype",
+				DownloadURL: "https://www.example.com",
+				Description: "Why hello there",
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "POST",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/extensions/someid",
+						Body:   mock.NewStringBody(`{"description":"Why hello there","download_url":"https://www.example.com","extension_type":"sometype","name":"Boop","version":"v1.0"}` + "\n"),
+					},
+					mock.NewStructBody(models.Extension{
+						ID:            ec.String("someid"),
+						Name:          ec.String("Boop"),
+						Version:       ec.String("v1.0"),
+						ExtensionType: ec.String("sometype"),
+						DownloadURL:   "https://www.example.com",
+						Description:   "Why hello there",
+					}),
+				)),
+			}},
+			want: &models.Extension{
+				ID:            ec.String("someid"),
+				Name:          ec.String("Boop"),
+				Version:       ec.String("v1.0"),
+				ExtensionType: ec.String("sometype"),
+				DownloadURL:   "https://www.example.com",
+				Description:   "Why hello there",
+			},
+		},
+		{
+			name: "fails on API error",
+			args: args{params: UpdateParams{
+				ExtensionID: "someid",
+				Type:        "sometype",
+				API: api.NewMock(mock.New500ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "POST",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/deployments/extensions/someid",
+						Body:   mock.NewStringBody(`{"extension_type":"sometype","name":"","version":""}` + "\n"),
+					},
+					mock.SampleInternalError().Response.Body,
+				)),
+			}},
+			err: mock.MultierrorInternalError.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Update(tt.args.params)
+			if err != nil && !assert.EqualError(t, err, tt.err) {
+				t.Error(err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
New APIs for all deployment extension CRUD APIs

## Related Issues
Related: https://github.com/elastic/terraform-provider-ec/pull/216

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
