### PR TITLE
multierror: Make concurrently safe and sort errors

### DIFF
--- a/pkg/api/platformapi/allocatorapi/search_test.go
+++ b/pkg/api/platformapi/allocatorapi/search_test.go
@@ -51,7 +51,7 @@ func TestSearch(t *testing.T) {
 					StatusCode: 200,
 				}}),
 			}},
-			err: "invalid allocator search params: 2 errors occurred:\n\t* validation failure list:\nvalidation failure list:\nvalidation failure list:\nfield in body is required\n\t* region not specified and is required for this operation\n\n",
+			err: "invalid allocator search params: 2 errors occurred:\n\t* region not specified and is required for this operation\n\t* validation failure list:\nvalidation failure list:\nvalidation failure list:\nfield in body is required\n\n",
 		},
 		{
 			name: "fails if api reference is empty",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
This PR adds both concurrency support for the `Prefixed` structure and
sorts to the `Errors` prior to `Error()` output.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Use the multierror.Prefixed concurrently and assert the error output.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
