### PR TITLE
deploymentapi: Add OverrideCreateOrUpdateRequest

### DIFF
--- a/pkg/api/deploymentapi/create.go
+++ b/pkg/api/deploymentapi/create.go
@@ -70,7 +70,11 @@ func Create(params CreateParams) (*models.DeploymentCreateResponse, error) {
 		return nil, err
 	}
 
-	setOverrides(params.Request, params.Overrides)
+	if err := OverrideCreateOrUpdateRequest(
+		params.Request, params.Overrides,
+	); err != nil {
+		return nil, err
+	}
 
 	var id *string
 	if params.RequestID != "" {

--- a/pkg/api/deploymentapi/override_settings.go
+++ b/pkg/api/deploymentapi/override_settings.go
@@ -19,8 +19,16 @@ package deploymentapi
 
 import (
 	"github.com/blang/semver/v4"
+
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+const (
+	defaultApmRefID              = "main-apm"
+	defaultAppsearchRefID        = "main-appsearch"
+	defaultEnterpriseSearchRefID = "main-enterprise_search"
+	defaultKibanaRefID           = "main-kibana"
 )
 
 var dataTiersMinVersion = semver.MustParse("7.10.0")
@@ -41,7 +49,7 @@ type PayloadOverrides struct {
 	Version string
 
 	// ElasticsearchRefID used for the applications.
-	ElasticcsearchRefID string
+	ElasticsearchRefID string
 
 	// OverrideRefIDs when set, it'll override all the application's ref_id.
 	OverrideRefIDs bool
@@ -85,7 +93,7 @@ func OverrideCreateOrUpdateRequest(req interface{}, overrides *PayloadOverrides)
 
 	return overrideByPayload(
 		apm, appsearch, elasticsearch, kibana, enterprisesearch,
-		overrides.Region, overrides.Version, overrides.ElasticcsearchRefID,
+		overrides.Region, overrides.Version, overrides.ElasticsearchRefID,
 		overrides.ElasticcsearchBuiltinPlugins, overrides.OverrideRefIDs,
 	)
 }
@@ -101,7 +109,7 @@ func overrideByPayload(apm []*models.ApmPayload, appsearch []*models.AppSearchPa
 		}
 
 		if overrideRefIDs {
-			resource.RefID = ec.String("main-apm")
+			resource.RefID = ec.String(defaultApmRefID)
 		}
 
 		if refID != "" {
@@ -121,7 +129,7 @@ func overrideByPayload(apm []*models.ApmPayload, appsearch []*models.AppSearchPa
 		}
 
 		if overrideRefIDs {
-			resource.RefID = ec.String("main-appsearch")
+			resource.RefID = ec.String(defaultAppsearchRefID)
 		}
 
 		if refID != "" {
@@ -179,7 +187,7 @@ func overrideByPayload(apm []*models.ApmPayload, appsearch []*models.AppSearchPa
 		}
 
 		if overrideRefIDs {
-			resource.RefID = ec.String("main-enterprise_search")
+			resource.RefID = ec.String(defaultEnterpriseSearchRefID)
 		}
 
 		if refID != "" {
@@ -199,7 +207,7 @@ func overrideByPayload(apm []*models.ApmPayload, appsearch []*models.AppSearchPa
 		}
 
 		if overrideRefIDs {
-			resource.RefID = ec.String("main-kibana")
+			resource.RefID = ec.String(defaultKibanaRefID)
 		}
 
 		if refID != "" {

--- a/pkg/api/deploymentapi/override_settings.go
+++ b/pkg/api/deploymentapi/override_settings.go
@@ -17,7 +17,13 @@
 
 package deploymentapi
 
-import "github.com/elastic/cloud-sdk-go/pkg/models"
+import (
+	"github.com/blang/semver/v4"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+var dataTiersMinVersion = semver.MustParse("7.10.0")
 
 // PayloadOverrides represent the override settings to
 type PayloadOverrides struct {
@@ -26,21 +32,30 @@ type PayloadOverrides struct {
 
 	// If set, it will override the region when not present in the
 	// DeploymentCreateRequest.
-	// Note this behaviour is different from the rest of overrides
+	// Note this behavior is different from the rest of overrides
 	// since this field tends to be populated by the global region
 	// field which is implicit (by config) rather than explicit by flag.
 	Region string
 
 	// If set, it'll override all versions to match this one.
 	Version string
+
+	// ElasticsearchRefID used for the applications.
+	ElasticcsearchRefID string
+
+	// OverrideRefIDs when set, it'll override all the application's ref_id.
+	OverrideRefIDs bool
+
+	// Slice of built-in enabled plugins.
+	ElasticcsearchBuiltinPlugins []string
 }
 
-// setOverrides sets a series of overrides to either the Create or Update
+// OverrideCreateOrUpdateRequest sets a series of overrides to either the Create or Update
 // deployment request. See PayloadOverrides to understand which how each
 // field of that struct affects the behavior of this function.
-func setOverrides(req interface{}, overrides *PayloadOverrides) {
+func OverrideCreateOrUpdateRequest(req interface{}, overrides *PayloadOverrides) error {
 	if req == nil || overrides == nil {
-		return
+		return nil
 	}
 
 	var apm []*models.ApmPayload
@@ -51,7 +66,7 @@ func setOverrides(req interface{}, overrides *PayloadOverrides) {
 	switch t := req.(type) {
 	case *models.DeploymentUpdateRequest:
 		if t.Resources == nil {
-			return
+			return nil
 		}
 		apm, appsearch = t.Resources.Apm, t.Resources.Appsearch
 		elasticsearch, kibana = t.Resources.Elasticsearch, t.Resources.Kibana
@@ -61,25 +76,36 @@ func setOverrides(req interface{}, overrides *PayloadOverrides) {
 			t.Name = overrides.Name
 		}
 		if t.Resources == nil {
-			return
+			return nil
 		}
 		apm, appsearch = t.Resources.Apm, t.Resources.Appsearch
 		elasticsearch, kibana = t.Resources.Elasticsearch, t.Resources.Kibana
 		enterprisesearch = t.Resources.EnterpriseSearch
 	}
 
-	overrideByPayload(
+	return overrideByPayload(
 		apm, appsearch, elasticsearch, kibana, enterprisesearch,
-		overrides.Region, overrides.Version,
+		overrides.Region, overrides.Version, overrides.ElasticcsearchRefID,
+		overrides.ElasticcsearchBuiltinPlugins, overrides.OverrideRefIDs,
 	)
 }
 
 // nolint
 func overrideByPayload(apm []*models.ApmPayload, appsearch []*models.AppSearchPayload,
-	elasticsearch []*models.ElasticsearchPayload, kibana []*models.KibanaPayload, enterprisesearch []*models.EnterpriseSearchPayload, region, version string) {
+	elasticsearch []*models.ElasticsearchPayload, kibana []*models.KibanaPayload,
+	enterprisesearch []*models.EnterpriseSearchPayload, region, version, refID string,
+	plugins []string, overrideRefIDs bool) error {
 	for _, resource := range apm {
 		if resource.Region == nil && region != "" {
 			resource.Region = &region
+		}
+
+		if overrideRefIDs {
+			resource.RefID = ec.String("main-apm")
+		}
+
+		if refID != "" {
+			resource.ElasticsearchClusterRefID = &refID
 		}
 
 		if version != "" {
@@ -94,6 +120,14 @@ func overrideByPayload(apm []*models.ApmPayload, appsearch []*models.AppSearchPa
 			resource.Region = &region
 		}
 
+		if overrideRefIDs {
+			resource.RefID = ec.String("main-appsearch")
+		}
+
+		if refID != "" {
+			resource.ElasticsearchClusterRefID = &refID
+		}
+
 		if version != "" {
 			if resource.Plan != nil && resource.Plan.Appsearch != nil {
 				resource.Plan.Appsearch.Version = version
@@ -106,9 +140,35 @@ func overrideByPayload(apm []*models.ApmPayload, appsearch []*models.AppSearchPa
 			resource.Region = &region
 		}
 
+		if refID != "" {
+			resource.RefID = &refID
+		}
+
+		// If version is empty, then data tiers are supported by default.
+		dataTierCompatible := true
 		if version != "" {
 			if resource.Plan != nil && resource.Plan.Elasticsearch != nil {
 				resource.Plan.Elasticsearch.Version = version
+				if len(plugins) > 0 {
+					resource.Plan.Elasticsearch.EnabledBuiltInPlugins = append(
+						resource.Plan.Elasticsearch.EnabledBuiltInPlugins, plugins...,
+					)
+				}
+
+				esVersion, err := semver.Parse(version)
+				if err != nil {
+					return err
+				}
+				dataTierCompatible = esVersion.GE(dataTiersMinVersion)
+			}
+		}
+		for _, top := range resource.Plan.ClusterTopology {
+			if len(top.NodeRoles) > 0 && top.NodeType != nil {
+				if dataTierCompatible {
+					top.NodeType = nil
+					continue
+				}
+				top.NodeRoles = nil
 			}
 		}
 	}
@@ -116,6 +176,14 @@ func overrideByPayload(apm []*models.ApmPayload, appsearch []*models.AppSearchPa
 	for _, resource := range enterprisesearch {
 		if resource.Region == nil && region != "" {
 			resource.Region = &region
+		}
+
+		if overrideRefIDs {
+			resource.RefID = ec.String("main-enterprise_search")
+		}
+
+		if refID != "" {
+			resource.ElasticsearchClusterRefID = &refID
 		}
 
 		if version != "" {
@@ -130,10 +198,20 @@ func overrideByPayload(apm []*models.ApmPayload, appsearch []*models.AppSearchPa
 			resource.Region = &region
 		}
 
+		if overrideRefIDs {
+			resource.RefID = ec.String("main-kibana")
+		}
+
+		if refID != "" {
+			resource.ElasticsearchClusterRefID = &refID
+		}
+
 		if version != "" {
 			if resource.Plan != nil && resource.Plan.Kibana != nil {
 				resource.Plan.Kibana.Version = version
 			}
 		}
 	}
+
+	return nil
 }

--- a/pkg/api/deploymentapi/override_settings_test.go
+++ b/pkg/api/deploymentapi/override_settings_test.go
@@ -56,11 +56,11 @@ func TestOverrideCreateOrUpdateRequest(t *testing.T) {
 			name: "set name, version, region and ref_id override",
 			args: args{
 				overrides: &PayloadOverrides{
-					Name:                "some other",
-					Version:             "7.4.1",
-					Region:              eceRegion,
-					ElasticcsearchRefID: "main-elasticsearch",
-					OverrideRefIDs:      true,
+					Name:               "some other",
+					Version:            "7.4.1",
+					Region:             eceRegion,
+					ElasticsearchRefID: "main-elasticsearch",
+					OverrideRefIDs:     true,
 				},
 				req: &models.DeploymentCreateRequest{
 					Name: "Some",
@@ -192,9 +192,9 @@ func TestOverrideCreateOrUpdateRequest(t *testing.T) {
 			name: "set region and ref_id override (no version leaves the NodeRoles field)",
 			args: args{
 				overrides: &PayloadOverrides{
-					Region:              eceRegion,
-					ElasticcsearchRefID: "main-elasticsearch",
-					OverrideRefIDs:      true,
+					Region:             eceRegion,
+					ElasticsearchRefID: "main-elasticsearch",
+					OverrideRefIDs:     true,
 				},
 				req: &models.DeploymentCreateRequest{
 					Name: "Some",
@@ -328,11 +328,11 @@ func TestOverrideCreateOrUpdateRequest(t *testing.T) {
 			name: "set name, version, region and ref_id override",
 			args: args{
 				overrides: &PayloadOverrides{
-					Name:                "some other",
-					Version:             "7.11.2",
-					Region:              eceRegion,
-					ElasticcsearchRefID: "main-elasticsearch",
-					OverrideRefIDs:      true,
+					Name:               "some other",
+					Version:            "7.11.2",
+					Region:             eceRegion,
+					ElasticsearchRefID: "main-elasticsearch",
+					OverrideRefIDs:     true,
 				},
 				req: &models.DeploymentCreateRequest{
 					Name: "Some",
@@ -466,10 +466,10 @@ func TestOverrideCreateOrUpdateRequest(t *testing.T) {
 			name: "set name, version, region with no ref_id override",
 			args: args{
 				overrides: &PayloadOverrides{
-					Name:                "some other",
-					Version:             "7.11.2",
-					Region:              eceRegion,
-					ElasticcsearchRefID: "main-elasticsearch",
+					Name:               "some other",
+					Version:            "7.11.2",
+					Region:             eceRegion,
+					ElasticsearchRefID: "main-elasticsearch",
 				},
 				req: &models.DeploymentCreateRequest{
 					Name: "Some",
@@ -607,9 +607,9 @@ func TestOverrideCreateOrUpdateRequest(t *testing.T) {
 			name: "set region override on a DeploymentUpdateRequest",
 			args: args{
 				overrides: &PayloadOverrides{
-					Region:              "overridden-region",
-					ElasticcsearchRefID: "main-elasticsearch",
-					OverrideRefIDs:      true,
+					Region:             "overridden-region",
+					ElasticsearchRefID: "main-elasticsearch",
+					OverrideRefIDs:     true,
 				},
 				req: &models.DeploymentUpdateRequest{
 					Resources: &models.DeploymentUpdateResources{

--- a/pkg/api/deploymentapi/override_settings_test.go
+++ b/pkg/api/deploymentapi/override_settings_test.go
@@ -23,9 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 )
 
-func Test_setOverrides(t *testing.T) {
+func TestOverrideCreateOrUpdateRequest(t *testing.T) {
 	var eceRegion = "ece-region"
 	var overriddenRegion = "overridden-region"
 	type args struct {
@@ -52,12 +53,14 @@ func Test_setOverrides(t *testing.T) {
 			},
 		},
 		{
-			name: "set name, version and region override",
+			name: "set name, version, region and ref_id override",
 			args: args{
 				overrides: &PayloadOverrides{
-					Name:    "some other",
-					Version: "7.4.1",
-					Region:  eceRegion,
+					Name:                "some other",
+					Version:             "7.4.1",
+					Region:              eceRegion,
+					ElasticcsearchRefID: "main-elasticsearch",
+					OverrideRefIDs:      true,
 				},
 				req: &models.DeploymentCreateRequest{
 					Name: "Some",
@@ -80,6 +83,25 @@ func Test_setOverrides(t *testing.T) {
 							{
 								Plan: &models.ElasticsearchClusterPlan{
 									Elasticsearch: &models.ElasticsearchConfiguration{Version: "1.2.3"},
+									ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+										{
+											ID: "hot_content",
+											NodeType: &models.ElasticsearchNodeType{
+												Master: ec.Bool(true),
+												Data:   ec.Bool(true),
+												Ingest: ec.Bool(true),
+												Ml:     ec.Bool(false),
+											},
+											NodeRoles: []string{
+												"master",
+												"ingest",
+												"remote_cluster_client",
+												"data_hot",
+												"transform",
+												"data_content",
+											},
+										},
+									},
 								},
 							},
 						},
@@ -109,6 +131,8 @@ func Test_setOverrides(t *testing.T) {
 							Plan: &models.ApmPlan{
 								Apm: &models.ApmConfiguration{Version: "7.4.1"},
 							},
+							RefID:                     ec.String("main-apm"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
 						},
 					},
 					Appsearch: []*models.AppSearchPayload{
@@ -117,6 +141,8 @@ func Test_setOverrides(t *testing.T) {
 							Plan: &models.AppSearchPlan{
 								Appsearch: &models.AppSearchConfiguration{Version: "7.4.1"},
 							},
+							RefID:                     ec.String("main-appsearch"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
 						},
 					},
 					Elasticsearch: []*models.ElasticsearchPayload{
@@ -124,7 +150,19 @@ func Test_setOverrides(t *testing.T) {
 							Region: &eceRegion,
 							Plan: &models.ElasticsearchClusterPlan{
 								Elasticsearch: &models.ElasticsearchConfiguration{Version: "7.4.1"},
+								ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+									{
+										ID: "hot_content",
+										NodeType: &models.ElasticsearchNodeType{
+											Master: ec.Bool(true),
+											Data:   ec.Bool(true),
+											Ingest: ec.Bool(true),
+											Ml:     ec.Bool(false),
+										},
+									},
+								},
 							},
+							RefID: ec.String("main-elasticsearch"),
 						},
 					},
 					EnterpriseSearch: []*models.EnterpriseSearchPayload{
@@ -133,6 +171,8 @@ func Test_setOverrides(t *testing.T) {
 							Plan: &models.EnterpriseSearchPlan{
 								EnterpriseSearch: &models.EnterpriseSearchConfiguration{Version: "7.4.1"},
 							},
+							RefID:                     ec.String("main-enterprise_search"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
 						},
 					},
 					Kibana: []*models.KibanaPayload{
@@ -141,6 +181,423 @@ func Test_setOverrides(t *testing.T) {
 							Plan: &models.KibanaClusterPlan{
 								Kibana: &models.KibanaConfiguration{Version: "7.4.1"},
 							},
+							RefID:                     ec.String("main-kibana"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "set region and ref_id override (no version leaves the NodeRoles field)",
+			args: args{
+				overrides: &PayloadOverrides{
+					Region:              eceRegion,
+					ElasticcsearchRefID: "main-elasticsearch",
+					OverrideRefIDs:      true,
+				},
+				req: &models.DeploymentCreateRequest{
+					Name: "Some",
+					Resources: &models.DeploymentCreateResources{
+						Apm: []*models.ApmPayload{
+							{
+								Plan: &models.ApmPlan{
+									Apm: &models.ApmConfiguration{},
+								},
+							},
+						},
+						Appsearch: []*models.AppSearchPayload{
+							{
+								Plan: &models.AppSearchPlan{
+									Appsearch: &models.AppSearchConfiguration{},
+								},
+							},
+						},
+						Elasticsearch: []*models.ElasticsearchPayload{
+							{
+								Plan: &models.ElasticsearchClusterPlan{
+									Elasticsearch: &models.ElasticsearchConfiguration{},
+									ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+										{
+											ID: "hot_content",
+											NodeType: &models.ElasticsearchNodeType{
+												Master: ec.Bool(true),
+												Data:   ec.Bool(true),
+												Ingest: ec.Bool(true),
+												Ml:     ec.Bool(false),
+											},
+											NodeRoles: []string{
+												"master",
+												"ingest",
+												"remote_cluster_client",
+												"data_hot",
+												"transform",
+												"data_content",
+											},
+										},
+									},
+								},
+							},
+						},
+						EnterpriseSearch: []*models.EnterpriseSearchPayload{
+							{
+								Plan: &models.EnterpriseSearchPlan{
+									EnterpriseSearch: &models.EnterpriseSearchConfiguration{},
+								},
+							},
+						},
+						Kibana: []*models.KibanaPayload{
+							{
+								Plan: &models.KibanaClusterPlan{
+									Kibana: &models.KibanaConfiguration{},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &models.DeploymentCreateRequest{
+				Name: "Some",
+				Resources: &models.DeploymentCreateResources{
+					Apm: []*models.ApmPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.ApmPlan{
+								Apm: &models.ApmConfiguration{},
+							},
+							RefID:                     ec.String("main-apm"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+						},
+					},
+					Appsearch: []*models.AppSearchPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.AppSearchPlan{
+								Appsearch: &models.AppSearchConfiguration{},
+							},
+							RefID:                     ec.String("main-appsearch"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+						},
+					},
+					Elasticsearch: []*models.ElasticsearchPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.ElasticsearchClusterPlan{
+								Elasticsearch: &models.ElasticsearchConfiguration{},
+								ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+									{
+										ID: "hot_content",
+										NodeRoles: []string{
+											"master",
+											"ingest",
+											"remote_cluster_client",
+											"data_hot",
+											"transform",
+											"data_content",
+										},
+									},
+								},
+							},
+							RefID: ec.String("main-elasticsearch"),
+						},
+					},
+					EnterpriseSearch: []*models.EnterpriseSearchPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.EnterpriseSearchPlan{
+								EnterpriseSearch: &models.EnterpriseSearchConfiguration{},
+							},
+							RefID:                     ec.String("main-enterprise_search"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+						},
+					},
+					Kibana: []*models.KibanaPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.KibanaClusterPlan{
+								Kibana: &models.KibanaConfiguration{},
+							},
+							RefID:                     ec.String("main-kibana"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "set name, version, region and ref_id override",
+			args: args{
+				overrides: &PayloadOverrides{
+					Name:                "some other",
+					Version:             "7.11.2",
+					Region:              eceRegion,
+					ElasticcsearchRefID: "main-elasticsearch",
+					OverrideRefIDs:      true,
+				},
+				req: &models.DeploymentCreateRequest{
+					Name: "Some",
+					Resources: &models.DeploymentCreateResources{
+						Apm: []*models.ApmPayload{
+							{
+								Plan: &models.ApmPlan{
+									Apm: &models.ApmConfiguration{Version: "1.2.3"},
+								},
+							},
+						},
+						Appsearch: []*models.AppSearchPayload{
+							{
+								Plan: &models.AppSearchPlan{
+									Appsearch: &models.AppSearchConfiguration{Version: "1.2.3"},
+								},
+							},
+						},
+						Elasticsearch: []*models.ElasticsearchPayload{
+							{
+								Plan: &models.ElasticsearchClusterPlan{
+									Elasticsearch: &models.ElasticsearchConfiguration{Version: "1.2.3"},
+									ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+										{
+											ID: "hot_content",
+											NodeType: &models.ElasticsearchNodeType{
+												Master: ec.Bool(true),
+												Data:   ec.Bool(true),
+												Ingest: ec.Bool(true),
+												Ml:     ec.Bool(false),
+											},
+											NodeRoles: []string{
+												"master",
+												"ingest",
+												"remote_cluster_client",
+												"data_hot",
+												"transform",
+												"data_content",
+											},
+										},
+									},
+								},
+							},
+						},
+						EnterpriseSearch: []*models.EnterpriseSearchPayload{
+							{
+								Plan: &models.EnterpriseSearchPlan{
+									EnterpriseSearch: &models.EnterpriseSearchConfiguration{Version: "1.2.3"},
+								},
+							},
+						},
+						Kibana: []*models.KibanaPayload{
+							{
+								Plan: &models.KibanaClusterPlan{
+									Kibana: &models.KibanaConfiguration{Version: "1.2.3"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &models.DeploymentCreateRequest{
+				Name: "some other",
+				Resources: &models.DeploymentCreateResources{
+					Apm: []*models.ApmPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.ApmPlan{
+								Apm: &models.ApmConfiguration{Version: "7.11.2"},
+							},
+							RefID:                     ec.String("main-apm"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+						},
+					},
+					Appsearch: []*models.AppSearchPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.AppSearchPlan{
+								Appsearch: &models.AppSearchConfiguration{Version: "7.11.2"},
+							},
+							RefID:                     ec.String("main-appsearch"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+						},
+					},
+					Elasticsearch: []*models.ElasticsearchPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.ElasticsearchClusterPlan{
+								Elasticsearch: &models.ElasticsearchConfiguration{Version: "7.11.2"},
+								ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+									{
+										ID: "hot_content",
+										NodeRoles: []string{
+											"master",
+											"ingest",
+											"remote_cluster_client",
+											"data_hot",
+											"transform",
+											"data_content",
+										},
+									},
+								},
+							},
+							RefID: ec.String("main-elasticsearch"),
+						},
+					},
+					EnterpriseSearch: []*models.EnterpriseSearchPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.EnterpriseSearchPlan{
+								EnterpriseSearch: &models.EnterpriseSearchConfiguration{Version: "7.11.2"},
+							},
+							RefID:                     ec.String("main-enterprise_search"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+						},
+					},
+					Kibana: []*models.KibanaPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.KibanaClusterPlan{
+								Kibana: &models.KibanaConfiguration{Version: "7.11.2"},
+							},
+							RefID:                     ec.String("main-kibana"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "set name, version, region with no ref_id override",
+			args: args{
+				overrides: &PayloadOverrides{
+					Name:                "some other",
+					Version:             "7.11.2",
+					Region:              eceRegion,
+					ElasticcsearchRefID: "main-elasticsearch",
+				},
+				req: &models.DeploymentCreateRequest{
+					Name: "Some",
+					Resources: &models.DeploymentCreateResources{
+						Apm: []*models.ApmPayload{
+							{
+								Plan: &models.ApmPlan{
+									Apm: &models.ApmConfiguration{Version: "1.2.3"},
+								},
+								RefID: ec.String("apm"),
+							},
+						},
+						Appsearch: []*models.AppSearchPayload{
+							{
+								Plan: &models.AppSearchPlan{
+									Appsearch: &models.AppSearchConfiguration{Version: "1.2.3"},
+								},
+								RefID: ec.String("appsearch"),
+							},
+						},
+						Elasticsearch: []*models.ElasticsearchPayload{
+							{
+								Plan: &models.ElasticsearchClusterPlan{
+									Elasticsearch: &models.ElasticsearchConfiguration{Version: "1.2.3"},
+									ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+										{
+											ID: "hot_content",
+											NodeType: &models.ElasticsearchNodeType{
+												Master: ec.Bool(true),
+												Data:   ec.Bool(true),
+												Ingest: ec.Bool(true),
+												Ml:     ec.Bool(false),
+											},
+											NodeRoles: []string{
+												"master",
+												"ingest",
+												"remote_cluster_client",
+												"data_hot",
+												"transform",
+												"data_content",
+											},
+										},
+									},
+								},
+							},
+						},
+						EnterpriseSearch: []*models.EnterpriseSearchPayload{
+							{
+								Plan: &models.EnterpriseSearchPlan{
+									EnterpriseSearch: &models.EnterpriseSearchConfiguration{Version: "1.2.3"},
+								},
+								RefID: ec.String("enterprise_search"),
+							},
+						},
+						Kibana: []*models.KibanaPayload{
+							{
+								Plan: &models.KibanaClusterPlan{
+									Kibana: &models.KibanaConfiguration{Version: "1.2.3"},
+								},
+								RefID: ec.String("kibana"),
+							},
+						},
+					},
+				},
+			},
+			want: &models.DeploymentCreateRequest{
+				Name: "some other",
+				Resources: &models.DeploymentCreateResources{
+					Apm: []*models.ApmPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.ApmPlan{
+								Apm: &models.ApmConfiguration{Version: "7.11.2"},
+							},
+							RefID:                     ec.String("apm"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+						},
+					},
+					Appsearch: []*models.AppSearchPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.AppSearchPlan{
+								Appsearch: &models.AppSearchConfiguration{Version: "7.11.2"},
+							},
+							RefID:                     ec.String("appsearch"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+						},
+					},
+					Elasticsearch: []*models.ElasticsearchPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.ElasticsearchClusterPlan{
+								Elasticsearch: &models.ElasticsearchConfiguration{Version: "7.11.2"},
+								ClusterTopology: []*models.ElasticsearchClusterTopologyElement{
+									{
+										ID: "hot_content",
+										NodeRoles: []string{
+											"master",
+											"ingest",
+											"remote_cluster_client",
+											"data_hot",
+											"transform",
+											"data_content",
+										},
+									},
+								},
+							},
+							RefID: ec.String("main-elasticsearch"),
+						},
+					},
+					EnterpriseSearch: []*models.EnterpriseSearchPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.EnterpriseSearchPlan{
+								EnterpriseSearch: &models.EnterpriseSearchConfiguration{Version: "7.11.2"},
+							},
+							RefID:                     ec.String("enterprise_search"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
+						},
+					},
+					Kibana: []*models.KibanaPayload{
+						{
+							Region: &eceRegion,
+							Plan: &models.KibanaClusterPlan{
+								Kibana: &models.KibanaConfiguration{Version: "7.11.2"},
+							},
+							RefID:                     ec.String("kibana"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
 						},
 					},
 				},
@@ -150,7 +607,9 @@ func Test_setOverrides(t *testing.T) {
 			name: "set region override on a DeploymentUpdateRequest",
 			args: args{
 				overrides: &PayloadOverrides{
-					Region: "overridden-region",
+					Region:              "overridden-region",
+					ElasticcsearchRefID: "main-elasticsearch",
+					OverrideRefIDs:      true,
 				},
 				req: &models.DeploymentUpdateRequest{
 					Resources: &models.DeploymentUpdateResources{
@@ -200,6 +659,8 @@ func Test_setOverrides(t *testing.T) {
 							Plan: &models.ApmPlan{
 								Apm: &models.ApmConfiguration{Version: "7.4.1"},
 							},
+							RefID:                     ec.String("main-apm"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
 						},
 					},
 					Appsearch: []*models.AppSearchPayload{
@@ -208,6 +669,8 @@ func Test_setOverrides(t *testing.T) {
 							Plan: &models.AppSearchPlan{
 								Appsearch: &models.AppSearchConfiguration{Version: "7.4.1"},
 							},
+							RefID:                     ec.String("main-appsearch"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
 						},
 					},
 					Elasticsearch: []*models.ElasticsearchPayload{
@@ -216,6 +679,7 @@ func Test_setOverrides(t *testing.T) {
 							Plan: &models.ElasticsearchClusterPlan{
 								Elasticsearch: &models.ElasticsearchConfiguration{Version: "7.4.1"},
 							},
+							RefID: ec.String("main-elasticsearch"),
 						},
 					},
 					EnterpriseSearch: []*models.EnterpriseSearchPayload{
@@ -224,6 +688,8 @@ func Test_setOverrides(t *testing.T) {
 							Plan: &models.EnterpriseSearchPlan{
 								EnterpriseSearch: &models.EnterpriseSearchConfiguration{Version: "7.4.1"},
 							},
+							RefID:                     ec.String("main-enterprise_search"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
 						},
 					},
 					Kibana: []*models.KibanaPayload{
@@ -232,6 +698,8 @@ func Test_setOverrides(t *testing.T) {
 							Plan: &models.KibanaClusterPlan{
 								Kibana: &models.KibanaConfiguration{Version: "7.4.1"},
 							},
+							RefID:                     ec.String("main-kibana"),
+							ElasticsearchClusterRefID: ec.String("main-elasticsearch"),
 						},
 					},
 				},
@@ -241,9 +709,9 @@ func Test_setOverrides(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var req = tt.args.req
-			setOverrides(req, tt.args.overrides)
+			OverrideCreateOrUpdateRequest(req, tt.args.overrides)
 
-			if !assert.Equal(t, req, tt.want) {
+			if !assert.Equal(t, tt.want, req) {
 				t.Errorf("setOverrides() = %v, want %v", req, tt.want)
 			}
 		})

--- a/pkg/api/deploymentapi/update.go
+++ b/pkg/api/deploymentapi/update.go
@@ -72,7 +72,11 @@ func Update(params UpdateParams) (*models.DeploymentUpdateResponse, error) {
 		return nil, err
 	}
 
-	setOverrides(params.Request, &params.Overrides)
+	if err := OverrideCreateOrUpdateRequest(
+		params.Request, &params.Overrides,
+	); err != nil {
+		return nil, err
+	}
 
 	res, err := params.V1API.Deployments.UpdateDeployment(
 		deployments.NewUpdateDeploymentParams().


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Adds a new public function `OverrideCreateOrUpdateRequest` which allows
setting certain overrides on the Deployment requests in the Create and
Update operations.

The function was private before making it part of the Create and Update
calls. This wasn't always desirable specially when pairing it with the
`--generate-payload` flag in `ecctl` where it wouldn't return the fields
that were overridden.

The function has been expanded to:

- Set overrides to all the application `ref_id` fields.
- ElasticsearchRefID overrides.
- Plugin overrides.
- Selection between node_roles and node_types when both are set.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
