### PR TITLE
trafficfilterapi: Fix bug in validation

### DIFF
--- a/pkg/api/deploymentapi/trafficfilterapi/create_association.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/create_association.go
@@ -57,7 +57,7 @@ func (params CreateAssociationParams) Validate() error {
 		merr = merr.Append(errors.New("entity id is not specified and is required for the operation"))
 	}
 
-	if params.ID == "" {
+	if params.EntityType == "" {
 		merr = merr.Append(errors.New("entity type is not specified and is required for the operation"))
 	}
 

--- a/pkg/api/deploymentapi/trafficfilterapi/create_association_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/create_association_test.go
@@ -40,10 +40,34 @@ func TestCreateAssociation(t *testing.T) {
 	}{
 		{
 			name: "fails due to parameter validation",
+			args: args{params: CreateAssociationParams{
+				EntityID:   "some-entity-id",
+				EntityType: "deployment",
+			}},
 			err: multierror.NewPrefixed("invalid traffic filter association create params",
 				apierror.ErrMissingAPI,
 				errors.New("rule set id is not specified and is required for the operation"),
+			).Error(),
+		},
+		{
+			name: "fails due to parameter validation",
+			args: args{params: CreateAssociationParams{
+				ID:         "some-id",
+				EntityType: "deployment",
+			}},
+			err: multierror.NewPrefixed("invalid traffic filter association create params",
+				apierror.ErrMissingAPI,
 				errors.New("entity id is not specified and is required for the operation"),
+			).Error(),
+		},
+		{
+			name: "fails due to parameter validation",
+			args: args{params: CreateAssociationParams{
+				ID:       "some-id",
+				EntityID: "some-entity-id",
+			}},
+			err: multierror.NewPrefixed("invalid traffic filter association create params",
+				apierror.ErrMissingAPI,
 				errors.New("entity type is not specified and is required for the operation"),
 			).Error(),
 		},

--- a/pkg/api/deploymentapi/trafficfilterapi/delete_association.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/delete_association.go
@@ -56,7 +56,7 @@ func (params DeleteAssociationParams) Validate() error {
 		merr = merr.Append(errors.New("entity id is not specified and is required for the operation"))
 	}
 
-	if params.ID == "" {
+	if params.EntityType == "" {
 		merr = merr.Append(errors.New("entity type is not specified and is required for the operation"))
 	}
 

--- a/pkg/api/deploymentapi/trafficfilterapi/delete_association_test.go
+++ b/pkg/api/deploymentapi/trafficfilterapi/delete_association_test.go
@@ -40,10 +40,34 @@ func TestDeleteAssociation(t *testing.T) {
 	}{
 		{
 			name: "fails due to parameter validation",
+			args: args{params: DeleteAssociationParams{
+				EntityID:   "some-entity-id",
+				EntityType: "deployment",
+			}},
 			err: multierror.NewPrefixed("invalid traffic filter association delete params",
 				apierror.ErrMissingAPI,
 				errors.New("rule set id is not specified and is required for the operation"),
+			).Error(),
+		},
+		{
+			name: "fails due to parameter validation",
+			args: args{params: DeleteAssociationParams{
+				ID:         "some-id",
+				EntityType: "deployment",
+			}},
+			err: multierror.NewPrefixed("invalid traffic filter association delete params",
+				apierror.ErrMissingAPI,
 				errors.New("entity id is not specified and is required for the operation"),
+			).Error(),
+		},
+		{
+			name: "fails due to parameter validation",
+			args: args{params: DeleteAssociationParams{
+				ID:       "some-id",
+				EntityID: "some-entity-id",
+			}},
+			err: multierror.NewPrefixed("invalid traffic filter association delete params",
+				apierror.ErrMissingAPI,
 				errors.New("entity type is not specified and is required for the operation"),
 			).Error(),
 		},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Fixes a bug in the validation for traffic filter association APIs where `params.ID` 
was being validated twice instead of `params.EntityType`.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

