### PR TITLE
align create comment operation validation messages

### DIFF
--- a/pkg/api/commentapi/create_params.go
+++ b/pkg/api/commentapi/create_params.go
@@ -43,14 +43,15 @@ func (params CreateParams) Validate() error {
 	}
 
 	if params.ResourceType == "" {
-		errs = errs.Append(errors.New("resource type is required"))
+		errs = errs.Append(errors.New("resource type is required for this operation"))
 	}
 
 	if params.ResourceID == "" {
-		errs = errs.Append(errors.New("resource id is required"))
+		errs = errs.Append(errors.New("resource id is required for this operation"))
 	}
+
 	if params.Message == "" {
-		errs = errs.Append(errors.New("message is required"))
+		errs = errs.Append(errors.New("message is required for this operation"))
 	}
 	return errs.ErrorOrNil()
 }

--- a/pkg/api/commentapi/create_params_test.go
+++ b/pkg/api/commentapi/create_params_test.go
@@ -38,9 +38,9 @@ func TestCreateParams_Validate(t *testing.T) {
 			err: multierror.NewPrefixed("invalid comment create params",
 				errors.New("region not specified and is required for this operation"),
 				errors.New("api reference is required for the operation"),
-				errors.New("resource type is required"),
-				errors.New("resource id is required"),
-				errors.New("message is required"),
+				errors.New("resource type is required for this operation"),
+				errors.New("resource id is required for this operation"),
+				errors.New("message is required for this operation"),
 			),
 		},
 		{

--- a/pkg/api/commentapi/create_test.go
+++ b/pkg/api/commentapi/create_test.go
@@ -43,9 +43,9 @@ func TestCreate(t *testing.T) {
 			err: multierror.NewPrefixed("invalid comment create params",
 				errors.New("region not specified and is required for this operation"),
 				errors.New("api reference is required for the operation"),
-				errors.New("resource type is required"),
-				errors.New("resource id is required"),
-				errors.New("message is required"),
+				errors.New("resource type is required for this operation"),
+				errors.New("resource id is required for this operation"),
+				errors.New("message is required for this operation"),
 			).Error(),
 		},
 		{


### PR DESCRIPTION
Aligns the validation error messages with the ones used in the other comment operations ( list and show so far )