### PR TITLE
implement comment delete operation

### DIFF
--- a/pkg/api/commentapi/delete.go
+++ b/pkg/api/commentapi/delete.go
@@ -1,0 +1,48 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package commentapi
+
+import (
+	"context"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/client/comments"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+// Delete delete the comment of the given combination of comment ID, version, resource type and resource ID.
+func Delete(params DeleteParams) error {
+	if err := params.Validate(); err != nil {
+		return err
+	}
+
+	_, err := params.V1API.Comments.DeleteComment(
+		comments.NewDeleteCommentParams().
+			WithContext(api.WithRegion(context.Background(), params.Region)).
+			WithVersion(ec.String(params.Version)).
+			WithCommentID(params.CommentID).
+			WithResourceType(params.ResourceType).
+			WithResourceID(params.ResourceID),
+		params.AuthWriter)
+
+	if err != nil {
+		return apierror.Wrap(err)
+	}
+	return nil
+}

--- a/pkg/api/commentapi/delete_params.go
+++ b/pkg/api/commentapi/delete_params.go
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package commentapi
+
+import (
+	"errors"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+// DeleteParams is consumed by the Delete function.
+type DeleteParams struct {
+	*api.API
+	ResourceType, ResourceID, CommentID, Region, Version string
+}
+
+// Validate ensures the parameters are usable by Delete.
+func (params DeleteParams) Validate() error {
+	errs := multierror.NewPrefixed("invalid comment delete params",
+		ec.RequireRegionSet(params.Region),
+	)
+
+	if params.API == nil {
+		errs = errs.Append(apierror.ErrMissingAPI)
+	}
+
+	if params.ResourceType == "" {
+		errs = errs.Append(errors.New("resource type is required for this operation"))
+	}
+
+	if params.ResourceID == "" {
+		errs = errs.Append(errors.New("resource id is required for this operation"))
+	}
+
+	if params.CommentID == "" {
+		errs = errs.Append(errors.New("comment id is required for this operation"))
+	}
+	return errs.ErrorOrNil()
+}

--- a/pkg/api/commentapi/delete_params_test.go
+++ b/pkg/api/commentapi/delete_params_test.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package commentapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteParams_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		params DeleteParams
+		err    error
+	}{
+		{
+			name:   "should return all validation errors",
+			params: DeleteParams{},
+			err: multierror.NewPrefixed("invalid comment delete params",
+				errors.New("region not specified and is required for this operation"),
+				errors.New("api reference is required for the operation"),
+				errors.New("resource type is required for this operation"),
+				errors.New("resource id is required for this operation"),
+				errors.New("comment id is required for this operation"),
+			),
+		},
+		{
+			name: "should return no validation errors",
+			params: DeleteParams{
+				API:          &api.API{},
+				ResourceType: "some-type",
+				ResourceID:   "some-id",
+				CommentID:    "some-comment-id",
+				Region:       "some-region",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.params.Validate()
+			if err != nil && tt.err == nil {
+				t.Fatalf("expected no errors but got %+v", err)
+			}
+			if err == nil && tt.err != nil {
+				t.Fatalf("expected errors %+v but got no errors", tt.err)
+			}
+			if err != nil && tt.err != nil {
+				assert.EqualError(t, err, tt.err.Error())
+			}
+		})
+	}
+}

--- a/pkg/api/commentapi/delete_test.go
+++ b/pkg/api/commentapi/delete_test.go
@@ -1,0 +1,131 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package commentapi
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestDelete(t *testing.T) {
+	type args struct {
+		params DeleteParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want *models.Comment
+		err  string
+	}{
+		{
+			name: "fails due to parameter validation",
+			err: multierror.NewPrefixed("invalid comment delete params",
+				errors.New("region not specified and is required for this operation"),
+				errors.New("api reference is required for the operation"),
+				errors.New("resource type is required for this operation"),
+				errors.New("resource id is required for this operation"),
+				errors.New("comment id is required for this operation"),
+			).Error(),
+		},
+		{
+			name: "succeeds",
+			args: args{params: DeleteParams{
+				Region:       "us-east-1",
+				ResourceID:   "some-resource-id",
+				ResourceType: "some-resource-type",
+				CommentID:    "some-comment-id",
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "DELETE",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/regions/us-east-1/comments/some-resource-type/some-resource-id/some-comment-id",
+					},
+					mock.NewStringBody(`{}`),
+				)),
+			}},
+			want: &models.Comment{
+				ID:      ec.String("random-generated-id"),
+				Message: ec.String("decrypted"),
+				UserID:  ec.String("lord-of-comments"),
+			},
+		},
+		{
+			name: "succeeds with a given version",
+			args: args{params: DeleteParams{
+				Region:       "us-east-1",
+				ResourceID:   "some-resource-id",
+				ResourceType: "some-resource-type",
+				CommentID:    "some-comment-id",
+				Version:      "v1",
+				API: api.NewMock(mock.New200ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "DELETE",
+						Path:   "/api/v1/regions/us-east-1/comments/some-resource-type/some-resource-id/some-comment-id",
+						Host:   api.DefaultMockHost,
+						Query: map[string][]string{
+							"version": {"v1"},
+						},
+					},
+					mock.NewStringBody(`{}`),
+				)),
+			}},
+			want: &models.Comment{
+				ID:      ec.String("random-generated-id"),
+				Message: ec.String("decrypted"),
+				UserID:  ec.String("lord-of-comments"),
+			},
+		},
+		{
+			name: "fails when api returns an error",
+			args: args{params: DeleteParams{
+				Region:       "us-east-1",
+				ResourceID:   "some-resource-id",
+				ResourceType: "some-resource-type",
+				CommentID:    "some-comment-id",
+				API: api.NewMock(mock.New500ResponseAssertion(
+					&mock.RequestAssertion{
+						Header: api.DefaultWriteMockHeaders,
+						Method: "DELETE",
+						Host:   api.DefaultMockHost,
+						Path:   "/api/v1/regions/us-east-1/comments/some-resource-type/some-resource-id/some-comment-id",
+					},
+					mock.SampleInternalError().Response.Body,
+				)),
+			}},
+			err: mock.MultierrorInternalError.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Delete(tt.args.params)
+			if err != nil && !assert.EqualError(t, err, tt.err) {
+				t.Error(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Introduces a new operation to delete a specific comment of a given resource. 

## Related Issues
Required by https://github.com/elastic/ecctl/issues/456

## How Has This Been Tested?
Unit tested and via `ecctl` - PR will follow

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed


