### PR TITLE
extensionapi: Functionality to build an update request form get

### DIFF
--- a/pkg/api/deploymentapi/extensionapi/update.go
+++ b/pkg/api/deploymentapi/extensionapi/update.go
@@ -33,12 +33,12 @@ import (
 type UpdateParams struct {
 	*api.API
 
-	ExtensionID string
-	Name        string
-	Version     string
-	Type        string
-	DownloadURL string
-	Description string
+	ExtensionID string `json:"extension_id,omitempty"`
+	Description string `json:"description,omitempty"`
+	DownloadURL string `json:"download_url,omitempty"`
+	Type        string `json:"extension_type"`
+	Name        string `json:"name"`
+	Version     string `json:"version"`
 }
 
 // Validate ensures the parameters are usable by Update.

--- a/pkg/api/deploymentapi/extensionapi/update_payload.go
+++ b/pkg/api/deploymentapi/extensionapi/update_payload.go
@@ -22,6 +22,7 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 )
 
+// NewUpdateRequestFromGet populates UpdateParams from models.Extension
 func NewUpdateRequestFromGet(res *models.Extension) *UpdateParams {
 	if res == nil {
 		return nil

--- a/pkg/api/deploymentapi/extensionapi/update_payload.go
+++ b/pkg/api/deploymentapi/extensionapi/update_payload.go
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package extensionapi
+
+import (
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func NewUpdateRequestFromGet(res *models.Extension) *UpdateParams {
+	if res == nil {
+		return nil
+	}
+
+	if res.ExtensionType == nil {
+		res.ExtensionType = ec.String("")
+	}
+
+	if res.Name == nil {
+		res.Name = ec.String("")
+	}
+
+	if res.Version == nil {
+		res.Version = ec.String("")
+	}
+
+	req := UpdateParams{
+		Description: res.Description,
+		DownloadURL: res.DownloadURL,
+		Type:        *res.ExtensionType,
+		Name:        *res.Name,
+		Version:     *res.Version,
+	}
+
+	return &req
+}

--- a/pkg/api/deploymentapi/extensionapi/update_payload_test.go
+++ b/pkg/api/deploymentapi/extensionapi/update_payload_test.go
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package extensionapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+)
+
+func TestNewUpdateRequestFromGet(t *testing.T) {
+	type args struct {
+		res *models.Extension
+	}
+	tests := []struct {
+		name string
+		args args
+		want *UpdateParams
+		err  string
+	}{
+		{
+			name: "succeeds with nil input",
+			args: args{res: nil},
+			want: nil,
+		},
+		{
+			name: "succeeds with empty input",
+			args: args{res: &models.Extension{}},
+			want: &UpdateParams{},
+		},
+		{
+			name: "succeeds",
+			args: args{res: &models.Extension{
+				Description:   "an extension",
+				DownloadURL:   "example.com",
+				ExtensionType: ec.String("plugin"),
+				Version:       ec.String("*"),
+				Name:          ec.String("my plugin"),
+				URL:           ec.String("some url"),
+			}},
+			want: &UpdateParams{
+				Description: "an extension",
+				DownloadURL: "example.com",
+				Type:        "plugin",
+				Version:     "*",
+				Name:        "my plugin",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewUpdateRequestFromGet(tt.args.res)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Adds new functionality to build an update request form get in order to be
able to generate an update payload in ecctl. https://github.com/elastic/ecctl/pull/477

## How Has This Been Tested?
unit tests and by running ecctl manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
