### PR TITLE
client: handle empty deployment template order fields in client generation

### DIFF
--- a/cmd/generator/cloudspec/spec_modifier.go
+++ b/cmd/generator/cloudspec/spec_modifier.go
@@ -53,6 +53,15 @@ func Modify(cloudSpec *spec.Swagger) {
 				cloudSpec.Definitions[k].Properties[kk] = prop
 			}
 
+			if k == "DeploymentTemplateInfoV2" && kk == "order" {
+				prop.AddExtension(nullableKey, true)
+				cloudSpec.Definitions[k].Properties[kk] = prop
+			}
+			if k == "DeploymentTemplateRequestBody" && kk == "order" {
+				prop.AddExtension(nullableKey, true)
+				cloudSpec.Definitions[k].Properties[kk] = prop
+			}
+
 			if k == "ElasticsearchConfiguration" {
 				if kk == "enabled_built_in_plugins" ||
 					kk == "user_bundles" ||

--- a/go.sum
+++ b/go.sum
@@ -136,7 +136,6 @@ github.com/go-openapi/strfmt v0.19.3/go.mod h1:0yX7dbo8mKIvc3XSKp7MNfxw4JytCfCD6
 github.com/go-openapi/strfmt v0.19.4/go.mod h1:eftuHTlB/dI8Uq8JJOyRlieZf+WkkxUuk0dgdHXr2Qk=
 github.com/go-openapi/strfmt v0.19.5/go.mod h1:eftuHTlB/dI8Uq8JJOyRlieZf+WkkxUuk0dgdHXr2Qk=
 github.com/go-openapi/strfmt v0.19.11/go.mod h1:UukAYgTaQfqJuAFlNxxMWNvMYiwiXtLsF2VwmoFtbtc=
-github.com/go-openapi/strfmt v0.20.0 h1:l2omNtmNbMc39IGptl9BuXBEKcZfS8zjrTsPKTiJiDM=
 github.com/go-openapi/strfmt v0.20.0/go.mod h1:UukAYgTaQfqJuAFlNxxMWNvMYiwiXtLsF2VwmoFtbtc=
 github.com/go-openapi/strfmt v0.20.1 h1:1VgxvehFne1mbChGeCmZ5pc0LxUf6yaACVSIYAR91Xc=
 github.com/go-openapi/strfmt v0.20.1/go.mod h1:43urheQI9dNtE5lTZQfuFJvjYJKPrxicATpEfZwHUNk=
@@ -148,7 +147,6 @@ github.com/go-openapi/swag v0.19.7/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfT
 github.com/go-openapi/swag v0.19.9/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfTe5McPyhY=
 github.com/go-openapi/swag v0.19.12/go.mod h1:eFdyEBkTdoAf/9RXBvj4cr1nH7GD8Kzo5HTt47gr72M=
 github.com/go-openapi/swag v0.19.13/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
-github.com/go-openapi/swag v0.19.14 h1:gm3vOOXfiuw5i9p5N9xJvfjvuofpyvLA9Wr6QfK5Fng=
 github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
 github.com/go-openapi/swag v0.19.15 h1:D2NRCBzS9/pEY3gP9Nl8aDqGUcPFrwG2p+CNFrLyrCM=
 github.com/go-openapi/swag v0.19.15/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
@@ -382,7 +380,6 @@ go.mongodb.org/mongo-driver v1.3.0/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS
 go.mongodb.org/mongo-driver v1.3.4/go.mod h1:MSWZXKOynuguX+JSvwP8i+58jYCXxbia8HS3gZBapIE=
 go.mongodb.org/mongo-driver v1.4.3/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
 go.mongodb.org/mongo-driver v1.4.4/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
-go.mongodb.org/mongo-driver v1.4.6 h1:rh7GdYmDrb8AQSkF8yteAus8qYOgOASWDOv1BWqBXkU=
 go.mongodb.org/mongo-driver v1.4.6/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
 go.mongodb.org/mongo-driver v1.5.1 h1:9nOVLGDfOaZ9R0tBumx/BcuqkbFpyTCU2r/Po7A2azI=
 go.mongodb.org/mongo-driver v1.5.1/go.mod h1:gRXCHX4Jo7J0IJ1oDQyUxF7jfy19UfxniMS4xxMmUqw=

--- a/pkg/models/deployment_template_info_v2.go
+++ b/pkg/models/deployment_template_info_v2.go
@@ -69,7 +69,7 @@ type DeploymentTemplateInfoV2 struct {
 	Name *string `json:"name"`
 
 	// Determines the order in which this template should be returned when listed. Templates are returned in ascending order. If not specified, then the template willbe appended to the end of the list.
-	Order int32 `json:"order,omitempty"`
+	Order *int32 `json:"order,omitempty"`
 
 	// Information describing the source that created or modified the template.
 	Source *ChangeSourceInfo `json:"source,omitempty"`

--- a/pkg/models/deployment_template_request_body.go
+++ b/pkg/models/deployment_template_request_body.go
@@ -61,7 +61,7 @@ type DeploymentTemplateRequestBody struct {
 	Name *string `json:"name"`
 
 	// Determines the order in which this template should be returned when listed. Templates are returned in ascending order. If not specified, then the template willbe appended to the end of the list.
-	Order int32 `json:"order,omitempty"`
+	Order *int32 `json:"order,omitempty"`
 
 	// Whether or not if this is system owned template.
 	SystemOwned *bool `json:"system_owned,omitempty"`


### PR DESCRIPTION
## Description
This PR hacks the new deployment template models' `order` field to handle the `0` value 
which is ignored if the field is not nullable. 

We have done the same in the old models and we missed the new ones.

## What problem we are solving?
When we are doing a `pull` all deployment templates that have order=0, are written as json files without this attribute.
This is caused by the `json` library which, during structure marshaling it ignores any int attributes with value = 0 ( because golang assumes this is the default value of all int )

