### PR TITLE
client: handle empty settings patch API operation in swagger client generation

### DIFF
--- a/pkg/client/platform_infrastructure/update_proxies_settings_parameters.go
+++ b/pkg/client/platform_infrastructure/update_proxies_settings_parameters.go
@@ -31,6 +31,8 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
 
 // NewUpdateProxiesSettingsParams creates a new UpdateProxiesSettingsParams object,
@@ -80,7 +82,7 @@ type UpdateProxiesSettingsParams struct {
 
 	   A JSON to merge with the existing settings
 	*/
-	Body string
+	Body *models.ProxiesSettings
 
 	/* Version.
 
@@ -142,13 +144,13 @@ func (o *UpdateProxiesSettingsParams) SetHTTPClient(client *http.Client) {
 }
 
 // WithBody adds the body to the update proxies settings params
-func (o *UpdateProxiesSettingsParams) WithBody(body string) *UpdateProxiesSettingsParams {
+func (o *UpdateProxiesSettingsParams) WithBody(body *models.ProxiesSettings) *UpdateProxiesSettingsParams {
 	o.SetBody(body)
 	return o
 }
 
 // SetBody adds the body to the update proxies settings params
-func (o *UpdateProxiesSettingsParams) SetBody(body string) {
+func (o *UpdateProxiesSettingsParams) SetBody(body *models.ProxiesSettings) {
 	o.Body = body
 }
 
@@ -170,8 +172,10 @@ func (o *UpdateProxiesSettingsParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
-	if err := r.SetBodyParam(o.Body); err != nil {
-		return err
+	if o.Body != nil {
+		if err := r.SetBodyParam(o.Body); err != nil {
+			return err
+		}
 	}
 
 	if o.Version != nil {

--- a/pkg/models/proxies_settings.go
+++ b/pkg/models/proxies_settings.go
@@ -28,7 +28,6 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/go-openapi/validate"
 )
 
 // ProxiesSettings The settings for all proxies.
@@ -37,39 +36,23 @@ import (
 type ProxiesSettings struct {
 
 	// Expected number of proxies
-	// Required: true
-	ExpectedProxiesCount *int32 `json:"expected_proxies_count"`
+	ExpectedProxiesCount *int32 `json:"expected_proxies_count,omitempty"`
 
 	// HTTP settings
-	// Required: true
-	HTTPSettings *ProxiesHTTPSettings `json:"http_settings"`
+	HTTPSettings *ProxiesHTTPSettings `json:"http_settings,omitempty"`
 
 	// Secret string for signature generation
-	// Required: true
-	SignatureSecret *string `json:"signature_secret"`
+	SignatureSecret *string `json:"signature_secret,omitempty"`
 
 	// Signature validity in milliseconds
-	// Required: true
-	SignatureValidForMillis *int64 `json:"signature_valid_for_millis"`
+	SignatureValidForMillis *int64 `json:"signature_valid_for_millis,omitempty"`
 }
 
 // Validate validates this proxies settings
 func (m *ProxiesSettings) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateExpectedProxiesCount(formats); err != nil {
-		res = append(res, err)
-	}
-
 	if err := m.validateHTTPSettings(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSignatureSecret(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateSignatureValidForMillis(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -79,19 +62,9 @@ func (m *ProxiesSettings) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *ProxiesSettings) validateExpectedProxiesCount(formats strfmt.Registry) error {
-
-	if err := validate.Required("expected_proxies_count", "body", m.ExpectedProxiesCount); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *ProxiesSettings) validateHTTPSettings(formats strfmt.Registry) error {
-
-	if err := validate.Required("http_settings", "body", m.HTTPSettings); err != nil {
-		return err
+	if swag.IsZero(m.HTTPSettings) { // not required
+		return nil
 	}
 
 	if m.HTTPSettings != nil {
@@ -101,24 +74,6 @@ func (m *ProxiesSettings) validateHTTPSettings(formats strfmt.Registry) error {
 			}
 			return err
 		}
-	}
-
-	return nil
-}
-
-func (m *ProxiesSettings) validateSignatureSecret(formats strfmt.Registry) error {
-
-	if err := validate.Required("signature_secret", "body", m.SignatureSecret); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *ProxiesSettings) validateSignatureValidForMillis(formats strfmt.Registry) error {
-
-	if err := validate.Required("signature_valid_for_millis", "body", m.SignatureValidForMillis); err != nil {
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
## Description
This address the well-known issue the PATCH methods provided by the admin-console API
The definition requires that the PATCH method accepts a `string` and not a structured `model`

This makes the generated go-client to send a string request body and not a json request body.

This PR does the following :

1. Hacks the swagger generation process to accept a `ProxiesSettings` structured model instead of a string
2. Removes all required fields from the structured model `ProxiesSettings`. If we don't remove them then json marshaling will add them with null values in the generated json body and this will cause the API to fail.

## Related Issues
Required by https://github.com/elastic/ecctl/issues/484 and https://github.com/elastic/ecctl/issues/483

## Motivation and Context
Support Patch API request against the proxies settings API

## How Has This Been Tested?
via `ecctl` PRs will follow 

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
