### PR TITLE
better way to call api to retrieve cluster plan when vacating allocators

### DIFF
--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -379,7 +379,7 @@ func fillVacateClusterParams(params *VacateClusterParams) (*VacateClusterParams,
 func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure.MoveClustersByTypeParams, error) {
 	// By setting the ClusterID in the request body, the API will only return the matched cluster's plan information.
 	// This greatly reduces the amount of work that the API has to perform to return the calculated plan.
-	req := GetVacateRequestByClusterID(params.ClusterID, params.Kind)
+	req := getVacateRequestByClusterID(params.ClusterID, params.Kind)
 
 	res, err := params.API.V1API.PlatformInfrastructure.MoveClusters(
 		platform_infrastructure.NewMoveClustersParams().
@@ -584,10 +584,10 @@ func CheckVacateFailures(failures *models.MoveClustersDetails, filter []string, 
 	return merr.ErrorOrNil()
 }
 
-// GetVacateRequestByClusterID makes models.MoveClusterRequest object which contains a cluster ID
+// getVacateRequestByClusterID makes models.MoveClusterRequest object which contains a cluster ID
 // and the object will be set to body of an API call which will retrieve calculated plan data to
 // be used to move a node.
-func GetVacateRequestByClusterID(clusterID, clusterType string) *models.MoveClustersRequest {
+func getVacateRequestByClusterID(clusterID, clusterType string) *models.MoveClustersRequest {
 	var req models.MoveClustersRequest
 
 	switch clusterType {

--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -283,6 +283,7 @@ func newVacateClusterParams(params addAllocatorMovesToPoolParams, id, kind strin
 		OutputFormat:        params.VacateParams.OutputFormat,
 		MoveOnly:            params.VacateParams.MoveOnly,
 		PlanOverrides:       params.VacateParams.PlanOverrides,
+		Moves:               params.Moves,
 	}
 }
 
@@ -377,26 +378,7 @@ func fillVacateClusterParams(params *VacateClusterParams) (*VacateClusterParams,
 
 // newMoveClusterParams
 func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure.MoveClustersByTypeParams, error) {
-	res, err := params.API.V1API.PlatformInfrastructure.MoveClusters(
-		platform_infrastructure.NewMoveClustersParams().
-			WithAllocatorDown(params.AllocatorDown).
-			WithMoveOnly(params.MoveOnly).
-			WithAllocatorID(params.ID).
-			WithContext(api.WithRegion(context.Background(), params.Region)).
-			WithValidateOnly(ec.Bool(true)),
-		params.AuthWriter,
-	)
-	if err != nil {
-		return nil, VacateError{
-			AllocatorID: params.ID,
-			ResourceID:  params.ClusterID,
-			Kind:        params.Kind,
-			Ctx:         "failed obtaining default vacate parameters",
-			Err:         apierror.Wrap(err),
-		}
-	}
-
-	req := ComputeVacateRequest(res.Payload.Moves,
+	req := ComputeVacateRequest(params.Moves,
 		[]string{params.ClusterID},
 		params.PreferredAllocators,
 		params.PlanOverrides,

--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -377,6 +377,9 @@ func fillVacateClusterParams(params *VacateClusterParams) (*VacateClusterParams,
 
 // newMoveClusterParams
 func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure.MoveClustersByTypeParams, error) {
+	// preparing MoveClustersRequest object to have ClusterID and the MoveClustersRequest object is set to request body when calling API.
+	// without ClusterID, the API will try to return all the plan information of every node in an allocator and it can be burden to backend adminconsole and zookeeper.
+	// so by setting the ClusterID in the request body, the API will return only matched cluster's plan information.
 	req := GetVacateRequestByClusterID(params.ClusterID, params.Kind)
 
 	res, err := params.API.V1API.PlatformInfrastructure.MoveClusters(

--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -377,8 +377,10 @@ func fillVacateClusterParams(params *VacateClusterParams) (*VacateClusterParams,
 
 // newMoveClusterParams
 func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure.MoveClustersByTypeParams, error) {
-	// preparing MoveClustersRequest object to have ClusterID and the MoveClustersRequest object is set to request body when calling API.
-	// without ClusterID, the API will try to return all the plan information of every node in an allocator and it can be burden to backend adminconsole and zookeeper.
+	// preparing MoveClustersRequest object to have ClusterID and the MoveClustersRequest object is
+	// set to request body when calling API.
+	// without ClusterID, the API will try to return all the plan information of every node in an allocator
+	// and it can be burden to backend adminconsole and zookeeper.
 	// so by setting the ClusterID in the request body, the API will return only matched cluster's plan information.
 	req := GetVacateRequestByClusterID(params.ClusterID, params.Kind)
 
@@ -586,7 +588,8 @@ func CheckVacateFailures(failures *models.MoveClustersDetails, filter []string, 
 }
 
 // GetVacateRequestByClusterID makes models.MoveClusterRequest object which contains a cluster ID
-// and the object will be set to body of an API call which will retrieve calculatedplan data to be used to move a node.
+// and the object will be set to body of an API call which will retrieve calculated plan data to
+// be used to move a node.
 func GetVacateRequestByClusterID(clusterID, clusterType string) *models.MoveClustersRequest {
 	var req models.MoveClustersRequest
 

--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -377,11 +377,8 @@ func fillVacateClusterParams(params *VacateClusterParams) (*VacateClusterParams,
 
 // newMoveClusterParams
 func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure.MoveClustersByTypeParams, error) {
-	// preparing MoveClustersRequest object to have ClusterID and the MoveClustersRequest object is
-	// set to request body when calling API.
-	// without ClusterID, the API will try to return all the plan information of every node in an allocator
-	// and it can be burden to backend adminconsole and zookeeper.
-	// so by setting the ClusterID in the request body, the API will return only matched cluster's plan information.
+	// By setting the ClusterID in the request body, the API will only return the matched cluster's plan information.
+	// This greatly reduces the amount of work that the API has to perform to return the calculated plan.
 	req := GetVacateRequestByClusterID(params.ClusterID, params.Kind)
 
 	res, err := params.API.V1API.PlatformInfrastructure.MoveClusters(

--- a/pkg/api/platformapi/allocatorapi/vacate_params.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_params.go
@@ -170,7 +170,6 @@ type VacateClusterParams struct {
 	OutputFormat   string
 	MaxPollRetries uint8
 	SkipTracking   bool
-	Moves          *models.MoveClustersDetails
 }
 
 // Validate validates the parameters
@@ -204,12 +203,6 @@ func (params VacateClusterParams) Validate() error {
 
 	if err := ec.RequireRegionSet(params.Region); err != nil {
 		merr = merr.Append(err)
-	}
-
-	if params.Moves == nil {
-		merr = merr.Append(
-			fmt.Errorf("cluster move plan should not be empty"),
-		)
 	}
 
 	return merr.ErrorOrNil()

--- a/pkg/api/platformapi/allocatorapi/vacate_params.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_params.go
@@ -170,6 +170,7 @@ type VacateClusterParams struct {
 	OutputFormat   string
 	MaxPollRetries uint8
 	SkipTracking   bool
+	Moves          *models.MoveClustersDetails
 }
 
 // Validate validates the parameters

--- a/pkg/api/platformapi/allocatorapi/vacate_params.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_params.go
@@ -159,7 +159,7 @@ type VacateClusterParams struct {
 	// Plan body overrides to place in all of the vacate clusters.
 	PlanOverrides
 	Region    string
-	ID        string
+	ID        string // allocatorID
 	ClusterID string
 	Kind      string
 	*api.API
@@ -204,6 +204,12 @@ func (params VacateClusterParams) Validate() error {
 
 	if err := ec.RequireRegionSet(params.Region); err != nil {
 		merr = merr.Append(err)
+	}
+
+	if params.Moves == nil {
+		merr = merr.Append(
+			fmt.Errorf("cluster move plan should not be empty"),
+		)
 	}
 
 	return merr.ErrorOrNil()

--- a/pkg/api/platformapi/allocatorapi/vacate_params_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_params_test.go
@@ -244,7 +244,6 @@ func TestVacateClusterParamsValidate(t *testing.T) {
 				errors.New("invalid kind "),
 				errOutputDeviceCannotBeNil,
 				errors.New("region not specified and is required for this operation"),
-				errors.New("cluster move plan should not be empty"),
 			).Error(),
 		},
 	}
@@ -265,7 +264,6 @@ func TestVacateClusterParamsValidate(t *testing.T) {
 				OutputFormat:        tt.fields.OutputFormat,
 				MaxPollRetries:      tt.fields.MaxPollRetries,
 				SkipTracking:        tt.fields.SkipTracking,
-				Moves:               tt.fields.Moves,
 			}
 			err := params.Validate()
 			if err != nil && !assert.EqualError(t, err, tt.err) {

--- a/pkg/api/platformapi/allocatorapi/vacate_responses_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_responses_test.go
@@ -622,23 +622,6 @@ func newAPMVacateMove(t *testing.T, alloc string, move vacateCaseClusterConfig, 
 				"/api/v1/regions/%s/platform/infrastructure/allocators/%s", region, alloc,
 			),
 		},
-	}, mock.Response{
-		Response: http.Response{
-			Body:       newApmMove(t, move.ID, alloc),
-			StatusCode: 202,
-		},
-		Assert: &mock.RequestAssertion{
-			Method: "POST",
-			Header: api.DefaultWriteMockHeaders,
-			Host:   api.DefaultMockHost,
-			Path: fmt.Sprintf(
-				"/api/v1/regions/%s/platform/infrastructure/allocators/%s/clusters/_move", region, alloc,
-			),
-			Query: url.Values{
-				"allocator_down": {"false"},
-				"validate_only":  {"true"},
-			},
-		},
 	})
 
 	if move.fail {
@@ -737,23 +720,6 @@ func newKibanaVacateMove(t *testing.T, alloc string, move vacateCaseClusterConfi
 				"/api/v1/regions/%s/platform/infrastructure/allocators/%s", region, alloc,
 			),
 		},
-	}, mock.Response{
-		Response: http.Response{
-			Body:       newKibanaMove(t, move.ID, alloc),
-			StatusCode: 202,
-		},
-		Assert: &mock.RequestAssertion{
-			Method: "POST",
-			Header: api.DefaultWriteMockHeaders,
-			Host:   api.DefaultMockHost,
-			Path: fmt.Sprintf(
-				"/api/v1/regions/%s/platform/infrastructure/allocators/%s/clusters/_move", region, alloc,
-			),
-			Query: url.Values{
-				"allocator_down": {"false"},
-				"validate_only":  {"true"},
-			},
-		},
 	})
 
 	if move.fail {
@@ -851,23 +817,6 @@ func newElasticsearchVacateMove(t *testing.T, alloc string, move vacateCaseClust
 				"/api/v1/regions/%s/platform/infrastructure/allocators/%s", region, alloc,
 			),
 		},
-	}, mock.Response{
-		Response: http.Response{
-			Body:       newElasticsearchMove(t, move.ID, alloc),
-			StatusCode: 202,
-		},
-		Assert: &mock.RequestAssertion{
-			Method: "POST",
-			Header: api.DefaultWriteMockHeaders,
-			Host:   api.DefaultMockHost,
-			Path: fmt.Sprintf(
-				"/api/v1/regions/%s/platform/infrastructure/allocators/%s/clusters/_move", region, alloc,
-			),
-			Query: url.Values{
-				"allocator_down": {"false"},
-				"validate_only":  {"true"},
-			},
-		},
 	})
 
 	if move.fail {
@@ -963,23 +912,6 @@ func newAppsearchVacateMove(t *testing.T, alloc string, move vacateCaseClusterCo
 			Path: fmt.Sprintf(
 				"/api/v1/regions/%s/platform/infrastructure/allocators/%s", region, alloc,
 			),
-		},
-	}, mock.Response{
-		Response: http.Response{
-			Body:       newAppsearchMove(t, move.ID, alloc),
-			StatusCode: 202,
-		},
-		Assert: &mock.RequestAssertion{
-			Method: "POST",
-			Header: api.DefaultWriteMockHeaders,
-			Host:   api.DefaultMockHost,
-			Path: fmt.Sprintf(
-				"/api/v1/regions/%s/platform/infrastructure/allocators/%s/clusters/_move", region, alloc,
-			),
-			Query: url.Values{
-				"allocator_down": {"false"},
-				"validate_only":  {"true"},
-			},
 		},
 	})
 
@@ -1078,23 +1010,6 @@ func newEnterpriseSearchVacateMove(t *testing.T, alloc string, move vacateCaseCl
 			Path: fmt.Sprintf(
 				"/api/v1/regions/%s/platform/infrastructure/allocators/%s", region, alloc,
 			),
-		},
-	}, mock.Response{
-		Response: http.Response{
-			Body:       newEnterpriseSearchMove(t, move.ID, alloc),
-			StatusCode: 202,
-		},
-		Assert: &mock.RequestAssertion{
-			Method: "POST",
-			Header: api.DefaultWriteMockHeaders,
-			Host:   api.DefaultMockHost,
-			Path: fmt.Sprintf(
-				"/api/v1/regions/%s/platform/infrastructure/allocators/%s/clusters/_move", region, alloc,
-			),
-			Query: url.Values{
-				"allocator_down": {"false"},
-				"validate_only":  {"true"},
-			},
 		},
 	})
 

--- a/pkg/api/platformapi/allocatorapi/vacate_responses_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_responses_test.go
@@ -622,6 +622,29 @@ func newAPMVacateMove(t *testing.T, alloc string, move vacateCaseClusterConfig, 
 				"/api/v1/regions/%s/platform/infrastructure/allocators/%s", region, alloc,
 			),
 		},
+	}, mock.Response{
+		Response: http.Response{
+			Body:       newApmMove(t, move.ID, alloc),
+			StatusCode: 202,
+		},
+		Assert: &mock.RequestAssertion{
+			Method: "POST",
+			Header: api.DefaultWriteMockHeaders,
+			Host:   api.DefaultMockHost,
+			Path: fmt.Sprintf(
+				"/api/v1/regions/%s/platform/infrastructure/allocators/%s/clusters/_move", region, alloc,
+			),
+			Query: url.Values{
+				"allocator_down": {"false"},
+				"validate_only":  {"true"},
+			},
+			Body: mock.NewStringBody(
+				fmt.Sprintf(
+					`{"apm_clusters":[{"cluster_ids":["%s"]}],"appsearch_clusters":null,"elasticsearch_clusters":null,"enterprise_search_clusters":null,"kibana_clusters":null}`+"\n",
+					move.ID,
+				),
+			),
+		},
 	})
 
 	if move.fail {
@@ -718,6 +741,29 @@ func newKibanaVacateMove(t *testing.T, alloc string, move vacateCaseClusterConfi
 			Host:   api.DefaultMockHost,
 			Path: fmt.Sprintf(
 				"/api/v1/regions/%s/platform/infrastructure/allocators/%s", region, alloc,
+			),
+		},
+	}, mock.Response{
+		Response: http.Response{
+			Body:       newKibanaMove(t, move.ID, alloc),
+			StatusCode: 202,
+		},
+		Assert: &mock.RequestAssertion{
+			Method: "POST",
+			Header: api.DefaultWriteMockHeaders,
+			Host:   api.DefaultMockHost,
+			Path: fmt.Sprintf(
+				"/api/v1/regions/%s/platform/infrastructure/allocators/%s/clusters/_move", region, alloc,
+			),
+			Query: url.Values{
+				"allocator_down": {"false"},
+				"validate_only":  {"true"},
+			},
+			Body: mock.NewStringBody(
+				fmt.Sprintf(
+					`{"apm_clusters":null,"appsearch_clusters":null,"elasticsearch_clusters":null,"enterprise_search_clusters":null,"kibana_clusters":[{"cluster_ids":["%s"]}]}`+"\n",
+					move.ID,
+				),
 			),
 		},
 	})
@@ -817,6 +863,29 @@ func newElasticsearchVacateMove(t *testing.T, alloc string, move vacateCaseClust
 				"/api/v1/regions/%s/platform/infrastructure/allocators/%s", region, alloc,
 			),
 		},
+	}, mock.Response{
+		Response: http.Response{
+			Body:       newElasticsearchMove(t, move.ID, alloc),
+			StatusCode: 202,
+		},
+		Assert: &mock.RequestAssertion{
+			Method: "POST",
+			Header: api.DefaultWriteMockHeaders,
+			Host:   api.DefaultMockHost,
+			Path: fmt.Sprintf(
+				"/api/v1/regions/%s/platform/infrastructure/allocators/%s/clusters/_move", region, alloc,
+			),
+			Query: url.Values{
+				"allocator_down": {"false"},
+				"validate_only":  {"true"},
+			},
+			Body: mock.NewStringBody(
+				fmt.Sprintf(
+					`{"apm_clusters":null,"appsearch_clusters":null,"elasticsearch_clusters":[{"cluster_ids":["%s"]}],"enterprise_search_clusters":null,"kibana_clusters":null}`+"\n",
+					move.ID,
+				),
+			),
+		},
 	})
 
 	if move.fail {
@@ -911,6 +980,29 @@ func newAppsearchVacateMove(t *testing.T, alloc string, move vacateCaseClusterCo
 			Host:   api.DefaultMockHost,
 			Path: fmt.Sprintf(
 				"/api/v1/regions/%s/platform/infrastructure/allocators/%s", region, alloc,
+			),
+		},
+	}, mock.Response{
+		Response: http.Response{
+			Body:       newAppsearchMove(t, move.ID, alloc),
+			StatusCode: 202,
+		},
+		Assert: &mock.RequestAssertion{
+			Method: "POST",
+			Header: api.DefaultWriteMockHeaders,
+			Host:   api.DefaultMockHost,
+			Path: fmt.Sprintf(
+				"/api/v1/regions/%s/platform/infrastructure/allocators/%s/clusters/_move", region, alloc,
+			),
+			Query: url.Values{
+				"allocator_down": {"false"},
+				"validate_only":  {"true"},
+			},
+			Body: mock.NewStringBody(
+				fmt.Sprintf(
+					`{"apm_clusters":null,"appsearch_clusters":[{"cluster_ids":["%s"]}],"elasticsearch_clusters":null,"enterprise_search_clusters":null,"kibana_clusters":null}`+"\n",
+					move.ID,
+				),
 			),
 		},
 	})
@@ -1009,6 +1101,29 @@ func newEnterpriseSearchVacateMove(t *testing.T, alloc string, move vacateCaseCl
 			Host:   api.DefaultMockHost,
 			Path: fmt.Sprintf(
 				"/api/v1/regions/%s/platform/infrastructure/allocators/%s", region, alloc,
+			),
+		},
+	}, mock.Response{
+		Response: http.Response{
+			Body:       newEnterpriseSearchMove(t, move.ID, alloc),
+			StatusCode: 202,
+		},
+		Assert: &mock.RequestAssertion{
+			Method: "POST",
+			Header: api.DefaultWriteMockHeaders,
+			Host:   api.DefaultMockHost,
+			Path: fmt.Sprintf(
+				"/api/v1/regions/%s/platform/infrastructure/allocators/%s/clusters/_move", region, alloc,
+			),
+			Query: url.Values{
+				"allocator_down": {"false"},
+				"validate_only":  {"true"},
+			},
+			Body: mock.NewStringBody(
+				fmt.Sprintf(
+					`{"apm_clusters":null,"appsearch_clusters":null,"elasticsearch_clusters":null,"enterprise_search_clusters":[{"cluster_ids":["%s"]}],"kibana_clusters":null}`+"\n",
+					move.ID,
+				),
 			),
 		},
 	})

--- a/pkg/api/platformapi/allocatorapi/vacate_responses_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_responses_test.go
@@ -638,12 +638,11 @@ func newAPMVacateMove(t *testing.T, alloc string, move vacateCaseClusterConfig, 
 				"allocator_down": {"false"},
 				"validate_only":  {"true"},
 			},
-			Body: mock.NewStringBody(
-				fmt.Sprintf(
-					`{"apm_clusters":[{"cluster_ids":["%s"]}],"appsearch_clusters":null,"elasticsearch_clusters":null,"enterprise_search_clusters":null,"kibana_clusters":null}`+"\n",
-					move.ID,
-				),
-			),
+			Body: mock.NewStructBody(models.MoveClustersRequest{
+				ApmClusters: []*models.MoveApmClusterConfiguration{{
+					ClusterIds: []string{move.ID},
+				}},
+			}),
 		},
 	})
 
@@ -759,12 +758,11 @@ func newKibanaVacateMove(t *testing.T, alloc string, move vacateCaseClusterConfi
 				"allocator_down": {"false"},
 				"validate_only":  {"true"},
 			},
-			Body: mock.NewStringBody(
-				fmt.Sprintf(
-					`{"apm_clusters":null,"appsearch_clusters":null,"elasticsearch_clusters":null,"enterprise_search_clusters":null,"kibana_clusters":[{"cluster_ids":["%s"]}]}`+"\n",
-					move.ID,
-				),
-			),
+			Body: mock.NewStructBody(models.MoveClustersRequest{
+				KibanaClusters: []*models.MoveKibanaClusterConfiguration{{
+					ClusterIds: []string{move.ID},
+				}},
+			}),
 		},
 	})
 
@@ -879,12 +877,11 @@ func newElasticsearchVacateMove(t *testing.T, alloc string, move vacateCaseClust
 				"allocator_down": {"false"},
 				"validate_only":  {"true"},
 			},
-			Body: mock.NewStringBody(
-				fmt.Sprintf(
-					`{"apm_clusters":null,"appsearch_clusters":null,"elasticsearch_clusters":[{"cluster_ids":["%s"]}],"enterprise_search_clusters":null,"kibana_clusters":null}`+"\n",
-					move.ID,
-				),
-			),
+			Body: mock.NewStructBody(models.MoveClustersRequest{
+				ElasticsearchClusters: []*models.MoveElasticsearchClusterConfiguration{{
+					ClusterIds: []string{move.ID},
+				}},
+			}),
 		},
 	})
 
@@ -998,12 +995,11 @@ func newAppsearchVacateMove(t *testing.T, alloc string, move vacateCaseClusterCo
 				"allocator_down": {"false"},
 				"validate_only":  {"true"},
 			},
-			Body: mock.NewStringBody(
-				fmt.Sprintf(
-					`{"apm_clusters":null,"appsearch_clusters":[{"cluster_ids":["%s"]}],"elasticsearch_clusters":null,"enterprise_search_clusters":null,"kibana_clusters":null}`+"\n",
-					move.ID,
-				),
-			),
+			Body: mock.NewStructBody(models.MoveClustersRequest{
+				AppsearchClusters: []*models.MoveAppSearchConfiguration{{
+					ClusterIds: []string{move.ID},
+				}},
+			}),
 		},
 	})
 
@@ -1119,12 +1115,11 @@ func newEnterpriseSearchVacateMove(t *testing.T, alloc string, move vacateCaseCl
 				"allocator_down": {"false"},
 				"validate_only":  {"true"},
 			},
-			Body: mock.NewStringBody(
-				fmt.Sprintf(
-					`{"apm_clusters":null,"appsearch_clusters":null,"elasticsearch_clusters":null,"enterprise_search_clusters":[{"cluster_ids":["%s"]}],"kibana_clusters":null}`+"\n",
-					move.ID,
-				),
-			),
+			Body: mock.NewStructBody(models.MoveClustersRequest{
+				EnterpriseSearchClusters: []*models.MoveEnterpriseSearchConfiguration{{
+					ClusterIds: []string{move.ID},
+				}},
+			}),
 		},
 	})
 

--- a/pkg/api/platformapi/allocatorapi/vacate_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"regexp"
 	"testing"
@@ -760,9 +761,8 @@ func TestCheckVacateFailures(t *testing.T) {
 }
 
 func TestVacateCluster(t *testing.T) {
-	var errEmptyParams = `allocator : resource id [][]: 7 errors occurred:
+	var errEmptyParams = `allocator : resource id [][]: 6 errors occurred:
 	* invalid allocator vacate params: api reference is required for the operation
-	* invalid allocator vacate params: cluster move plan should not be empty
 	* invalid allocator vacate params: invalid allocator ID 
 	* invalid allocator vacate params: invalid cluster ID 
 	* invalid allocator vacate params: invalid kind 
@@ -770,9 +770,8 @@ func TestVacateCluster(t *testing.T) {
 	* invalid allocator vacate params: region not specified and is required for this operation
 
 `
-	var errInvalidParams = `allocator someID: resource id [3ee11eb40eda22cac0cce259625c6734][somethingweird]: 5 errors occurred:
+	var errInvalidParams = `allocator someID: resource id [3ee11eb40eda22cac0cce259625c6734][somethingweird]: 4 errors occurred:
 	* invalid allocator vacate params: api reference is required for the operation
-	* invalid allocator vacate params: cluster move plan should not be empty
 	* invalid allocator vacate params: invalid kind somethingweird
 	* invalid allocator vacate params: output device cannot be nil
 	* invalid allocator vacate params: region not specified and is required for this operation
@@ -838,20 +837,6 @@ func TestVacateCluster(t *testing.T) {
 							newPlanStep("plan-completed", "success"),
 						},
 					}, "us-east-1")),
-					Moves: &models.MoveClustersDetails{
-						ElasticsearchClusters: []*models.MoveElasticsearchClusterDetails{{
-							ClusterID: ec.String("3ee11eb40eda22cac0cce259625c6734"),
-							CalculatedPlan: &models.TransientElasticsearchPlanConfiguration{
-								PlanConfiguration: &models.ElasticsearchPlanControlConfiguration{
-									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
-								},
-							},
-							Errors: []*models.BasicFailedReplyElement{{
-								Code:    ec.String("a code"),
-								Message: ec.String("a message"),
-							}},
-						}},
-					},
 				},
 			},
 			want: newOutputResponses(
@@ -877,16 +862,6 @@ func TestVacateCluster(t *testing.T) {
 							ID: "3ee11eb40eda22cac0cce259625c6734",
 						}, "us-east-1"),
 					),
-					Moves: &models.MoveClustersDetails{
-						ElasticsearchClusters: []*models.MoveElasticsearchClusterDetails{{
-							ClusterID: ec.String("3ee11eb40eda22cac0cce259625c6734"),
-							CalculatedPlan: &models.TransientElasticsearchPlanConfiguration{
-								PlanConfiguration: &models.ElasticsearchPlanControlConfiguration{
-									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
-								},
-							},
-						}},
-					},
 				},
 			},
 		},
@@ -923,16 +898,6 @@ func TestVacateCluster(t *testing.T) {
 							newPlanStep("plan-completed", "success"),
 						},
 					}, "us-east-1")),
-					Moves: &models.MoveClustersDetails{
-						KibanaClusters: []*models.MoveKibanaClusterDetails{{
-							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
-							CalculatedPlan: &models.TransientKibanaPlanConfiguration{
-								PlanConfiguration: &models.KibanaPlanControlConfiguration{
-									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
-								},
-							},
-						}},
-					},
 				},
 			},
 			want: newOutputResponses(
@@ -959,16 +924,6 @@ func TestVacateCluster(t *testing.T) {
 							ID: "2ee11eb40eda22cac0cce259625c6734",
 						}, "us-east-1"),
 					),
-					Moves: &models.MoveClustersDetails{
-						KibanaClusters: []*models.MoveKibanaClusterDetails{{
-							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
-							CalculatedPlan: &models.TransientKibanaPlanConfiguration{
-								PlanConfiguration: &models.KibanaPlanControlConfiguration{
-									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
-								},
-							},
-						}},
-					},
 				},
 			},
 		},
@@ -990,16 +945,6 @@ func TestVacateCluster(t *testing.T) {
 							ID: "2ee11eb40eda22cac0cce259625c6734",
 						}, "us-east-1"),
 					),
-					Moves: &models.MoveClustersDetails{
-						AppsearchClusters: []*models.MoveAppSearchDetails{{
-							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
-							CalculatedPlan: &models.TransientAppSearchPlanConfiguration{
-								PlanConfiguration: &models.AppSearchPlanControlConfiguration{
-									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
-								},
-							},
-						}},
-					},
 				},
 			},
 		},
@@ -1036,16 +981,6 @@ func TestVacateCluster(t *testing.T) {
 							newPlanStep("plan-completed", "success"),
 						},
 					}, "us-east-1")),
-					Moves: &models.MoveClustersDetails{
-						EnterpriseSearchClusters: []*models.MoveEnterpriseSearchDetails{{
-							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
-							CalculatedPlan: &models.TransientEnterpriseSearchPlanConfiguration{
-								PlanConfiguration: &models.EnterpriseSearchPlanControlConfiguration{
-									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
-								},
-							},
-						}},
-					},
 				},
 			},
 			want: newOutputResponses(
@@ -1072,16 +1007,6 @@ func TestVacateCluster(t *testing.T) {
 							ID: "2ee11eb40eda22cac0cce259625c6734",
 						}, "us-east-1"),
 					),
-					Moves: &models.MoveClustersDetails{
-						EnterpriseSearchClusters: []*models.MoveEnterpriseSearchDetails{{
-							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
-							CalculatedPlan: &models.TransientEnterpriseSearchPlanConfiguration{
-								PlanConfiguration: &models.EnterpriseSearchPlanControlConfiguration{
-									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
-								},
-							},
-						}},
-					},
 				},
 			},
 		},
@@ -1101,16 +1026,6 @@ func TestVacateCluster(t *testing.T) {
 						ID:   "2ee11eb40eda22cac0cce259625c6734",
 						fail: true,
 					}, "us-east-1")),
-					Moves: &models.MoveClustersDetails{
-						EnterpriseSearchClusters: []*models.MoveEnterpriseSearchDetails{{
-							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
-							CalculatedPlan: &models.TransientEnterpriseSearchPlanConfiguration{
-								PlanConfiguration: &models.EnterpriseSearchPlanControlConfiguration{
-									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
-								},
-							},
-						}},
-					},
 				},
 			},
 			err: multierror.NewPrefixed("vacate error", VacateError{
@@ -1138,16 +1053,6 @@ func TestVacateCluster(t *testing.T) {
 						ID:   "2ee11eb40eda22cac0cce259625c6734",
 						fail: true,
 					}, "us-east-1")),
-					Moves: &models.MoveClustersDetails{
-						EnterpriseSearchClusters: []*models.MoveEnterpriseSearchDetails{{
-							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
-							CalculatedPlan: &models.TransientEnterpriseSearchPlanConfiguration{
-								PlanConfiguration: &models.EnterpriseSearchPlanControlConfiguration{
-									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
-								},
-							},
-						}},
-					},
 				},
 			},
 			err: `{
@@ -1181,16 +1086,6 @@ func TestVacateCluster(t *testing.T) {
 						ID:   "2ee11eb40eda22cac0cce259625c6734",
 						fail: true,
 					}, "us-east-1")),
-					Moves: &models.MoveClustersDetails{
-						KibanaClusters: []*models.MoveKibanaClusterDetails{{
-							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
-							CalculatedPlan: &models.TransientKibanaPlanConfiguration{
-								PlanConfiguration: &models.KibanaPlanControlConfiguration{
-									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
-								},
-							},
-						}},
-					},
 				},
 			},
 			err: multierror.NewPrefixed("vacate error", VacateError{
@@ -1244,7 +1139,6 @@ func Test_fillVacateClusterParams(t *testing.T) {
 					ClusterID: "3ee11eb40eda22cac0cce259625c6734",
 					Kind:      "elasticsearch",
 					Output:    output.NewDevice(new(bytes.Buffer)),
-					Moves:     new(models.MoveClustersDetails),
 				},
 			},
 			err: `allocator allocator-1: resource id [3ee11eb40eda22cac0cce259625c6734][elasticsearch]: allocator health autodiscovery: Get "https://mock.elastic.co/api/v1/regions/us-east-1/platform/infrastructure/allocators/allocator-1": unauthorized`,
@@ -1262,7 +1156,6 @@ func Test_fillVacateClusterParams(t *testing.T) {
 					ClusterID: "3ee11eb40eda22cac0cce259625c6734",
 					Kind:      "elasticsearch",
 					Output:    output.NewDevice(new(bytes.Buffer)),
-					Moves:     new(models.MoveClustersDetails),
 				},
 			},
 			want: &VacateClusterParams{
@@ -1274,7 +1167,6 @@ func Test_fillVacateClusterParams(t *testing.T) {
 				MaxPollRetries: util.DefaultRetries,
 				TrackFrequency: util.DefaultPollFrequency,
 				AllocatorDown:  ec.Bool(false),
-				Moves:          new(models.MoveClustersDetails),
 			},
 		},
 		{
@@ -1293,7 +1185,6 @@ func Test_fillVacateClusterParams(t *testing.T) {
 					MaxPollRetries: 4,
 					AllocatorDown:  ec.Bool(true),
 					TrackFrequency: time.Millisecond,
-					Moves:          new(models.MoveClustersDetails),
 				},
 			},
 			want: &VacateClusterParams{
@@ -1305,7 +1196,6 @@ func Test_fillVacateClusterParams(t *testing.T) {
 				MaxPollRetries: 4,
 				TrackFrequency: time.Millisecond,
 				AllocatorDown:  ec.Bool(true),
-				Moves:          new(models.MoveClustersDetails),
 			},
 		},
 	}
@@ -1336,6 +1226,28 @@ func Test_newMoveClusterParams(t *testing.T) {
 		err  string
 	}{
 		{
+			name: "when an API error is returned, the error is properly wrapped",
+			args: args{params: &VacateClusterParams{
+				API:       api.NewMock(mock.Response{Error: errors.New("unauthorized")}),
+				ID:        "allocator-1",
+				Region:    "us-east-1",
+				ClusterID: "3ee11eb40eda22cac0cce259625c6734",
+				Kind:      "elasticsearch",
+				Output:    output.NewDevice(new(bytes.Buffer)),
+			}},
+			err: VacateError{
+				AllocatorID: "allocator-1",
+				ResourceID:  "3ee11eb40eda22cac0cce259625c6734",
+				Kind:        util.Elasticsearch,
+				Ctx:         "failed obtaining default vacate parameters",
+				Err: &url.Error{
+					Op:  "Post",
+					URL: "https://mock.elastic.co/api/v1/regions/us-east-1/platform/infrastructure/allocators/allocator-1/clusters/_move?validate_only=true",
+					Err: errors.New("unauthorized"),
+				},
+			}.Error(),
+		},
+		{
 			name: "elasticsearch move succeeds to get parameters on an elasticsearch resource",
 			args: args{params: &VacateClusterParams{
 				API: api.NewMock(mock.Response{Response: http.Response{
@@ -1348,16 +1260,6 @@ func Test_newMoveClusterParams(t *testing.T) {
 				Kind:          "elasticsearch",
 				Output:        output.NewDevice(new(bytes.Buffer)),
 				AllocatorDown: ec.Bool(false),
-				Moves: &models.MoveClustersDetails{
-					ElasticsearchClusters: []*models.MoveElasticsearchClusterDetails{{
-						ClusterID: ec.String("3ee11eb40eda22cac0cce259625c6734"),
-						CalculatedPlan: &models.TransientElasticsearchPlanConfiguration{
-							PlanConfiguration: &models.ElasticsearchPlanControlConfiguration{
-								MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("allocator-1")}},
-							},
-						},
-					}},
-				},
 			}},
 			want: platform_infrastructure.NewMoveClustersByTypeParams().
 				WithAllocatorID("allocator-1").
@@ -1394,16 +1296,6 @@ func Test_newMoveClusterParams(t *testing.T) {
 				Kind:          util.Apm,
 				Output:        output.NewDevice(new(bytes.Buffer)),
 				AllocatorDown: ec.Bool(false),
-				Moves: &models.MoveClustersDetails{
-					ApmClusters: []*models.MoveApmClusterDetails{{
-						ClusterID: ec.String("3ee11eb40eda22cac0cce259625c6734"),
-						CalculatedPlan: &models.TransientApmPlanConfiguration{
-							PlanConfiguration: &models.ApmPlanControlConfiguration{
-								MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("allocator-1")}},
-							},
-						},
-					}},
-				},
 			}},
 			want: platform_infrastructure.NewMoveClustersByTypeParams().
 				WithAllocatorID("allocator-1").

--- a/pkg/api/platformapi/allocatorapi/vacate_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"reflect"
 	"regexp"
 	"testing"
@@ -761,8 +760,9 @@ func TestCheckVacateFailures(t *testing.T) {
 }
 
 func TestVacateCluster(t *testing.T) {
-	var errEmptyParams = `allocator : resource id [][]: 6 errors occurred:
+	var errEmptyParams = `allocator : resource id [][]: 7 errors occurred:
 	* invalid allocator vacate params: api reference is required for the operation
+	* invalid allocator vacate params: cluster move plan should not be empty
 	* invalid allocator vacate params: invalid allocator ID 
 	* invalid allocator vacate params: invalid cluster ID 
 	* invalid allocator vacate params: invalid kind 
@@ -770,8 +770,9 @@ func TestVacateCluster(t *testing.T) {
 	* invalid allocator vacate params: region not specified and is required for this operation
 
 `
-	var errInvalidParams = `allocator someID: resource id [3ee11eb40eda22cac0cce259625c6734][somethingweird]: 4 errors occurred:
+	var errInvalidParams = `allocator someID: resource id [3ee11eb40eda22cac0cce259625c6734][somethingweird]: 5 errors occurred:
 	* invalid allocator vacate params: api reference is required for the operation
+	* invalid allocator vacate params: cluster move plan should not be empty
 	* invalid allocator vacate params: invalid kind somethingweird
 	* invalid allocator vacate params: output device cannot be nil
 	* invalid allocator vacate params: region not specified and is required for this operation
@@ -837,6 +838,20 @@ func TestVacateCluster(t *testing.T) {
 							newPlanStep("plan-completed", "success"),
 						},
 					}, "us-east-1")),
+					Moves: &models.MoveClustersDetails{
+						ElasticsearchClusters: []*models.MoveElasticsearchClusterDetails{{
+							ClusterID: ec.String("3ee11eb40eda22cac0cce259625c6734"),
+							CalculatedPlan: &models.TransientElasticsearchPlanConfiguration{
+								PlanConfiguration: &models.ElasticsearchPlanControlConfiguration{
+									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
+								},
+							},
+							Errors: []*models.BasicFailedReplyElement{{
+								Code:    ec.String("a code"),
+								Message: ec.String("a message"),
+							}},
+						}},
+					},
 				},
 			},
 			want: newOutputResponses(
@@ -862,6 +877,16 @@ func TestVacateCluster(t *testing.T) {
 							ID: "3ee11eb40eda22cac0cce259625c6734",
 						}, "us-east-1"),
 					),
+					Moves: &models.MoveClustersDetails{
+						ElasticsearchClusters: []*models.MoveElasticsearchClusterDetails{{
+							ClusterID: ec.String("3ee11eb40eda22cac0cce259625c6734"),
+							CalculatedPlan: &models.TransientElasticsearchPlanConfiguration{
+								PlanConfiguration: &models.ElasticsearchPlanControlConfiguration{
+									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
+								},
+							},
+						}},
+					},
 				},
 			},
 		},
@@ -898,6 +923,16 @@ func TestVacateCluster(t *testing.T) {
 							newPlanStep("plan-completed", "success"),
 						},
 					}, "us-east-1")),
+					Moves: &models.MoveClustersDetails{
+						KibanaClusters: []*models.MoveKibanaClusterDetails{{
+							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
+							CalculatedPlan: &models.TransientKibanaPlanConfiguration{
+								PlanConfiguration: &models.KibanaPlanControlConfiguration{
+									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
+								},
+							},
+						}},
+					},
 				},
 			},
 			want: newOutputResponses(
@@ -924,6 +959,16 @@ func TestVacateCluster(t *testing.T) {
 							ID: "2ee11eb40eda22cac0cce259625c6734",
 						}, "us-east-1"),
 					),
+					Moves: &models.MoveClustersDetails{
+						KibanaClusters: []*models.MoveKibanaClusterDetails{{
+							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
+							CalculatedPlan: &models.TransientKibanaPlanConfiguration{
+								PlanConfiguration: &models.KibanaPlanControlConfiguration{
+									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
+								},
+							},
+						}},
+					},
 				},
 			},
 		},
@@ -941,10 +986,20 @@ func TestVacateCluster(t *testing.T) {
 					SkipTracking:   true,
 					MaxPollRetries: 1,
 					API: discardResponses(
-						newKibanaVacateMove(t, "someID", vacateCaseClusterConfig{
+						newAppsearchVacateMove(t, "someID", vacateCaseClusterConfig{
 							ID: "2ee11eb40eda22cac0cce259625c6734",
 						}, "us-east-1"),
 					),
+					Moves: &models.MoveClustersDetails{
+						AppsearchClusters: []*models.MoveAppSearchDetails{{
+							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
+							CalculatedPlan: &models.TransientAppSearchPlanConfiguration{
+								PlanConfiguration: &models.AppSearchPlanControlConfiguration{
+									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
+								},
+							},
+						}},
+					},
 				},
 			},
 		},
@@ -981,6 +1036,16 @@ func TestVacateCluster(t *testing.T) {
 							newPlanStep("plan-completed", "success"),
 						},
 					}, "us-east-1")),
+					Moves: &models.MoveClustersDetails{
+						EnterpriseSearchClusters: []*models.MoveEnterpriseSearchDetails{{
+							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
+							CalculatedPlan: &models.TransientEnterpriseSearchPlanConfiguration{
+								PlanConfiguration: &models.EnterpriseSearchPlanControlConfiguration{
+									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
+								},
+							},
+						}},
+					},
 				},
 			},
 			want: newOutputResponses(
@@ -1007,6 +1072,16 @@ func TestVacateCluster(t *testing.T) {
 							ID: "2ee11eb40eda22cac0cce259625c6734",
 						}, "us-east-1"),
 					),
+					Moves: &models.MoveClustersDetails{
+						EnterpriseSearchClusters: []*models.MoveEnterpriseSearchDetails{{
+							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
+							CalculatedPlan: &models.TransientEnterpriseSearchPlanConfiguration{
+								PlanConfiguration: &models.EnterpriseSearchPlanControlConfiguration{
+									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
+								},
+							},
+						}},
+					},
 				},
 			},
 		},
@@ -1026,6 +1101,16 @@ func TestVacateCluster(t *testing.T) {
 						ID:   "2ee11eb40eda22cac0cce259625c6734",
 						fail: true,
 					}, "us-east-1")),
+					Moves: &models.MoveClustersDetails{
+						EnterpriseSearchClusters: []*models.MoveEnterpriseSearchDetails{{
+							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
+							CalculatedPlan: &models.TransientEnterpriseSearchPlanConfiguration{
+								PlanConfiguration: &models.EnterpriseSearchPlanControlConfiguration{
+									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
+								},
+							},
+						}},
+					},
 				},
 			},
 			err: multierror.NewPrefixed("vacate error", VacateError{
@@ -1053,6 +1138,16 @@ func TestVacateCluster(t *testing.T) {
 						ID:   "2ee11eb40eda22cac0cce259625c6734",
 						fail: true,
 					}, "us-east-1")),
+					Moves: &models.MoveClustersDetails{
+						EnterpriseSearchClusters: []*models.MoveEnterpriseSearchDetails{{
+							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
+							CalculatedPlan: &models.TransientEnterpriseSearchPlanConfiguration{
+								PlanConfiguration: &models.EnterpriseSearchPlanControlConfiguration{
+									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
+								},
+							},
+						}},
+					},
 				},
 			},
 			err: `{
@@ -1086,6 +1181,16 @@ func TestVacateCluster(t *testing.T) {
 						ID:   "2ee11eb40eda22cac0cce259625c6734",
 						fail: true,
 					}, "us-east-1")),
+					Moves: &models.MoveClustersDetails{
+						KibanaClusters: []*models.MoveKibanaClusterDetails{{
+							ClusterID: ec.String("2ee11eb40eda22cac0cce259625c6734"),
+							CalculatedPlan: &models.TransientKibanaPlanConfiguration{
+								PlanConfiguration: &models.KibanaPlanControlConfiguration{
+									MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("someID")}},
+								},
+							},
+						}},
+					},
 				},
 			},
 			err: multierror.NewPrefixed("vacate error", VacateError{
@@ -1139,6 +1244,7 @@ func Test_fillVacateClusterParams(t *testing.T) {
 					ClusterID: "3ee11eb40eda22cac0cce259625c6734",
 					Kind:      "elasticsearch",
 					Output:    output.NewDevice(new(bytes.Buffer)),
+					Moves:     new(models.MoveClustersDetails),
 				},
 			},
 			err: `allocator allocator-1: resource id [3ee11eb40eda22cac0cce259625c6734][elasticsearch]: allocator health autodiscovery: Get "https://mock.elastic.co/api/v1/regions/us-east-1/platform/infrastructure/allocators/allocator-1": unauthorized`,
@@ -1156,6 +1262,7 @@ func Test_fillVacateClusterParams(t *testing.T) {
 					ClusterID: "3ee11eb40eda22cac0cce259625c6734",
 					Kind:      "elasticsearch",
 					Output:    output.NewDevice(new(bytes.Buffer)),
+					Moves:     new(models.MoveClustersDetails),
 				},
 			},
 			want: &VacateClusterParams{
@@ -1167,6 +1274,7 @@ func Test_fillVacateClusterParams(t *testing.T) {
 				MaxPollRetries: util.DefaultRetries,
 				TrackFrequency: util.DefaultPollFrequency,
 				AllocatorDown:  ec.Bool(false),
+				Moves:          new(models.MoveClustersDetails),
 			},
 		},
 		{
@@ -1185,6 +1293,7 @@ func Test_fillVacateClusterParams(t *testing.T) {
 					MaxPollRetries: 4,
 					AllocatorDown:  ec.Bool(true),
 					TrackFrequency: time.Millisecond,
+					Moves:          new(models.MoveClustersDetails),
 				},
 			},
 			want: &VacateClusterParams{
@@ -1196,6 +1305,7 @@ func Test_fillVacateClusterParams(t *testing.T) {
 				MaxPollRetries: 4,
 				TrackFrequency: time.Millisecond,
 				AllocatorDown:  ec.Bool(true),
+				Moves:          new(models.MoveClustersDetails),
 			},
 		},
 	}
@@ -1226,28 +1336,6 @@ func Test_newMoveClusterParams(t *testing.T) {
 		err  string
 	}{
 		{
-			name: "when an API error is returned, the error is properly wrapped",
-			args: args{params: &VacateClusterParams{
-				API:       api.NewMock(mock.Response{Error: errors.New("unauthorized")}),
-				ID:        "allocator-1",
-				Region:    "us-east-1",
-				ClusterID: "3ee11eb40eda22cac0cce259625c6734",
-				Kind:      "elasticsearch",
-				Output:    output.NewDevice(new(bytes.Buffer)),
-			}},
-			err: VacateError{
-				AllocatorID: "allocator-1",
-				ResourceID:  "3ee11eb40eda22cac0cce259625c6734",
-				Kind:        util.Elasticsearch,
-				Ctx:         "failed obtaining default vacate parameters",
-				Err: &url.Error{
-					Op:  "Post",
-					URL: "https://mock.elastic.co/api/v1/regions/us-east-1/platform/infrastructure/allocators/allocator-1/clusters/_move?validate_only=true",
-					Err: errors.New("unauthorized"),
-				},
-			}.Error(),
-		},
-		{
 			name: "elasticsearch move succeeds to get parameters on an elasticsearch resource",
 			args: args{params: &VacateClusterParams{
 				API: api.NewMock(mock.Response{Response: http.Response{
@@ -1260,6 +1348,16 @@ func Test_newMoveClusterParams(t *testing.T) {
 				Kind:          "elasticsearch",
 				Output:        output.NewDevice(new(bytes.Buffer)),
 				AllocatorDown: ec.Bool(false),
+				Moves: &models.MoveClustersDetails{
+					ElasticsearchClusters: []*models.MoveElasticsearchClusterDetails{{
+						ClusterID: ec.String("3ee11eb40eda22cac0cce259625c6734"),
+						CalculatedPlan: &models.TransientElasticsearchPlanConfiguration{
+							PlanConfiguration: &models.ElasticsearchPlanControlConfiguration{
+								MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("allocator-1")}},
+							},
+						},
+					}},
+				},
 			}},
 			want: platform_infrastructure.NewMoveClustersByTypeParams().
 				WithAllocatorID("allocator-1").
@@ -1296,6 +1394,16 @@ func Test_newMoveClusterParams(t *testing.T) {
 				Kind:          util.Apm,
 				Output:        output.NewDevice(new(bytes.Buffer)),
 				AllocatorDown: ec.Bool(false),
+				Moves: &models.MoveClustersDetails{
+					ApmClusters: []*models.MoveApmClusterDetails{{
+						ClusterID: ec.String("3ee11eb40eda22cac0cce259625c6734"),
+						CalculatedPlan: &models.TransientApmPlanConfiguration{
+							PlanConfiguration: &models.ApmPlanControlConfiguration{
+								MoveAllocators: []*models.AllocatorMoveRequest{{From: ec.String("allocator-1")}},
+							},
+						},
+					}},
+				},
 			}},
 			want: platform_infrastructure.NewMoveClustersByTypeParams().
 				WithAllocatorID("allocator-1").


### PR DESCRIPTION
## Description
When vacating some packed allocators, it sometimes fails to start to vacate allocators because of time out when calling adminconsole API.

I found that when the vacate logic prepare cluster's plan to apply to each cluster, it is hitting adminconsole API a lot of times.

And the response of every call to the API have every plan of every cluster in an allocator.

When actual calling actual vacate API, it only uses the cluster's own calculated plan data and do not use others'.

And I think I fix this behavior to call API to return only each cluster's plan.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Rel: https://github.com/elastic/cloud/issues/78915

## Motivation and Context
Explained in the description section.

## How Has This Been Tested?
I tested the change running debugger but I did not make change in unit tests.
- [x] unit tests
- [x] tested actual vacating with an [allocator](https://admin.staging.foundit.no/region/azure-eastus2/hosts/26399008-82fd-4705-b592-fc3bbb1c81fb/allocator) in staging.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
