### PR TITLE
deps: Remove last trace of gobin

### DIFF
--- a/build/Makefile.apivalidation
+++ b/build/Makefile.apivalidation
@@ -25,7 +25,7 @@ wait-on-proxy:
 	@ until nc -z -w 2 localhost $(EXTERNAL_PORT); do sleep 5; done
 
 .PHONY: apivalidation-deps
-apivalidation-deps: $(GOBIN)/gobin $(GOBIN)/gotestsum $(GOBIN)/apivalidator
+apivalidation-deps: $(GOBIN)/gotestsum $(GOBIN)/apivalidator
 
 #### GitHub interaction targets
 

--- a/build/Makefile.deps
+++ b/build/Makefile.deps
@@ -20,10 +20,6 @@ $(GOBIN):
 $(VERSION_DIR): | $(GOBIN)
 	@ mkdir -p $(GOBIN)/versions
 
-$(VERSION_DIR)/.version-gobin-$(VERSION_GOBIN): | $(VERSION_DIR)
-	@ rm -f $(VERSION_DIR)/.version-gobin-*
-	@ echo $(VERSION_GOBIN) > $(VERSION_DIR)/.version-gobin-$(VERSION_GOBIN)
-
 $(VERSION_DIR)/.version-go-licenser-$(VERSION_GOLICENSER): | $(VERSION_DIR)
 	@ rm -f $(VERSION_DIR)/.version-go-licenser-*
 	@ echo $(VERSION_GOLICENSER) > $(VERSION_DIR)/.version-go-licenser-$(VERSION_GOLICENSER)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Removes the last references of the gobin binary. The "api-validation"
job failed overnight because it was still referencing a gobin target.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See https://github.com/elastic/cloud-sdk-go/runs/3376135556?check_suite_focus=true#step:5:107

