### PR TITLE
Add auto-commit of NOTICE file on PR

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,6 +39,9 @@ jobs:
       id: unit
 
     - name: Commit generated files
-      uses: stefanzweifel/git-auto-commit-action@v4
+      uses: EndBug/add-and-commit@v7
       with:
-        commit_message: Add auto-generated files
+        default_author: user_info
+        message: 'Add auto-generated files'
+        author_name: elasticcloudclients
+        author_email: elasticcloudclients@elastic.co

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,3 +37,8 @@ jobs:
     - name: Run unit tests
       run: make unit
       id: unit
+
+    - name: Commit generated files
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Add auto-generated files

--- a/build/Makefile.deps
+++ b/build/Makefile.deps
@@ -80,6 +80,7 @@ mod:
 	@ echo "-> Downloading project imports..."
 	@ go mod download
 	@ go mod tidy
+	@ $(GOBIN)/go-licenser -license ASL2
 
 ## Alias to make mod.
 .PHONY: vendor

--- a/build/Makefile.dev
+++ b/build/Makefile.dev
@@ -16,7 +16,6 @@ unit: _report_path
 .PHONY: format
 format: deps
 	@ echo "-> Formatting Go files..."
-	@ $(GOBIN)/go-licenser -license ASL2
 	@ $(GOBIN)/golangci-lint run --fix
 	@ echo "-> Done."
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
This PR move generation of `NOTICE` file to `make vendor` to keep it similar as in other public tools. And also it adds a Github Action to commit changed file back to PR

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
