### PR TITLE
release: Describe the git tag on master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,16 @@ jobs:
           go-version: 1.17
         id: go
 
+      - name: Get the branch version
+        id: get_branch
+        run: |
+          TNAME=${GITHUB_REF/refs\/tags\//}
+          if ${{github.event_name == 'workflow_dispatch'}}; then
+            TNAME=$(git describe --abbrev=0 --tags)
+          fi
+          echo ::set-output name=BRANCH::$(echo ${TNAME} | cut -d '.' -f1-2 | tr -d 'v')
+          echo ::set-output name=TAGNAME::$(echo ${TNAME} | cut -d '.' -f1-3)
+
       - name: Bump main version
         run: make minor; git diff
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail. -->
Fixes the release flow when manually triggered, since it was not pulling
the tags from the remote, this caused the `versionbump` binary to fail
the tag check (`-c` option) and thus failed the build.

