### PR TITLE
Enable auto-generated NOTICE on commit

### DIFF
--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -1,4 +1,4 @@
-name: Generate CHANGELOG
+name: Generate CHANGELOG and NOTICE
 on:
   push:
   workflow_dispatch:
@@ -17,13 +17,13 @@ jobs:
           go-version: 1.17
         id: go
 
-      - run: make changelog
+      - run: make format changelog
       - name: Commit & Push changes
         run: |
           if [[ ! -z  $(git status --porcelain) ]]; then
             git config --local user.email elasticcloudclients@elastic.co
             git config --local user.name elasticcloudclients
-            git add notes
-            git commit -m "Update changelog"
+            git add notes NOTICE
+            git commit -m "Update changelog and NOTICE"
             git push
           fi

--- a/NOTICE
+++ b/NOTICE
@@ -28,4 +28,5 @@ github.com/kr/pretty                   MIT
 github.com/mattn/go-colorable          MIT
 github.com/hashicorp/go-multierror     MPL-2.0-no-copyleft-exception
 
+
 =========================================================================

--- a/build/Makefile.dev
+++ b/build/Makefile.dev
@@ -16,7 +16,7 @@ unit: _report_path
 .PHONY: format
 format: deps
 	@ echo "-> Formatting Go files..."
-	@ $(GOBIN)/go-licenser -license ASL2
+	@ $(GOBIN)/go-licenser -license ASL2 -notice .
 	@ $(GOBIN)/golangci-lint run --fix
 	@ echo "-> Done."
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
This PR adds auto-generation of `NOTICE` file on every commit to `master`. Right now we are missing any automation around that.
Unfortunately, it can be tested only after merge.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Similar to https://github.com/elastic/terraform-provider-ec/pull/372

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
