### PR TITLE
Add 409 response to Mock API client

### DIFF
--- a/pkg/api/mock/response.go
+++ b/pkg/api/mock/response.go
@@ -89,6 +89,14 @@ func New404Response(body io.ReadCloser) Response {
 	}}
 }
 
+// New409Response creates a new response with a statuscode 409
+func New409Response(body io.ReadCloser) Response {
+	return Response{Response: http.Response{
+		StatusCode: 409,
+		Body:       populateBody(body),
+	}}
+}
+
 // New500Response creates a new response with a statuscode 500
 func New500Response(body io.ReadCloser) Response {
 	return Response{Response: http.Response{
@@ -135,6 +143,17 @@ func New404ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Re
 	return Response{
 		Response: http.Response{
 			StatusCode: 404,
+			Body:       populateBody(body),
+		},
+		Assert: assertion,
+	}
+}
+
+// New409ResponseAssertion creates a new response with request assertion and a statuscode 409
+func New409ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Response {
+	return Response{
+		Response: http.Response{
+			StatusCode: 409,
 			Body:       populateBody(body),
 		},
 		Assert: assertion,

--- a/pkg/api/mock/response_test.go
+++ b/pkg/api/mock/response_test.go
@@ -188,6 +188,44 @@ func TestNew404Response(t *testing.T) {
 	}
 }
 
+func TestNew409Response(t *testing.T) {
+	bodyBuffer := NewStringBody("409")
+	type args struct {
+		body io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 409",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 409,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 409 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 409,
+				Body:       bodyBuffer,
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New409Response(tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New409Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNew500Response(t *testing.T) {
 	bodyBuffer := NewStringBody("500")
 	type args struct {
@@ -438,6 +476,59 @@ func TestNew404ResponseAssertion(t *testing.T) {
 	}
 }
 
+func TestNew409ResponseAssertion(t *testing.T) {
+	bodyBuffer := NewStringBody("409")
+	type args struct {
+		assertion *RequestAssertion
+		body      io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 409",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 409,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 409 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 409,
+				Body:       bodyBuffer,
+			}},
+		},
+		{
+			name: "Returns statuscode 409 with body and request assertion",
+			args: args{
+				assertion: mockRequestAssertion,
+				body:      bodyBuffer,
+			},
+			want: Response{
+				Response: http.Response{
+					StatusCode: 409,
+					Body:       bodyBuffer,
+				},
+				Assert: mockRequestAssertion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New409ResponseAssertion(tt.args.assertion, tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New409Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNew500ResponseAssertion(t *testing.T) {
 	bodyBuffer := NewStringBody("500")
 	type args struct {
@@ -565,6 +656,14 @@ func TestNewStructResponse(t *testing.T) {
 			args: args{i: S{}, code: 404},
 			want: Response{Response: http.Response{
 				StatusCode: 404,
+				Body:       structBody,
+			}},
+		},
+		{
+			name: "get a 409 response",
+			args: args{i: S{}, code: 409},
+			want: Response{Response: http.Response{
+				StatusCode: 409,
 				Body:       structBody,
 			}},
 		},


### PR DESCRIPTION
It adds HTTP `409` response to Mock API client.

## Description
To be able to run acceptance tests in TF ElasticCloud provider, we need to mock API client and e.g. to check whether a [role already exists](https://github.com/elastic/cloud-sdk-go/blob/master/pkg/client/platform_infrastructure/delete_blueprinter_role_responses.go#L61-L62), we need to return that HTTP code.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

---

Metas: https://github.com/elastic/cloud/issues/93118 https://github.com/elastic/cloud/issues/93122
Rel: https://github.com/elastic/cloud/issues/93121
