### PR TITLE
userapi/authapi: Add API validation in CreateKey

### DIFF
--- a/pkg/api/userapi/authapi/createkey.go
+++ b/pkg/api/userapi/authapi/createkey.go
@@ -39,6 +39,9 @@ type CreateKeyParams struct {
 func (params CreateKeyParams) Validate() error {
 	var merr = multierror.NewPrefixed("invalid user auth params")
 
+	if params.API == nil {
+		merr = merr.Append(apierror.ErrMissingAPI)
+	}
 	if params.Description == "" {
 		merr = merr.Append(errors.New("key description is not specified and is required for this operation"))
 	}

--- a/pkg/api/userapi/authapi/createkey_test.go
+++ b/pkg/api/userapi/authapi/createkey_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
+	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
 	"github.com/elastic/cloud-sdk-go/pkg/api/mock"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
@@ -53,6 +54,7 @@ func TestCreateKey(t *testing.T) {
 		{
 			name: "fails due to parameter validation",
 			err: multierror.NewPrefixed("invalid user auth params",
+				apierror.ErrMissingAPI,
 				errors.New("key description is not specified and is required for this operation"),
 			).Error(),
 		},
@@ -60,7 +62,7 @@ func TestCreateKey(t *testing.T) {
 			name: "fails due to reauthenticate API error",
 			args: args{params: CreateKeyParams{
 				Description: "some description",
-				API:      api.NewMock(mock.NewErrorResponse(400, invalidPassErrType)),
+				API:         api.NewMock(mock.NewErrorResponse(400, invalidPassErrType)),
 			}},
 			err: multierror.NewPrefixed("api error",
 				errors.New("auth.invalid_password: request password doesn't match the user's password (body.password)"),


### PR DESCRIPTION
## Description
Adds the missing `api.API` validation in `CreateKeyParams.Validate()`.

