### PR TITLE
Add missing responses to Mock API client

### DIFF
--- a/pkg/api/mock/response.go
+++ b/pkg/api/mock/response.go
@@ -81,6 +81,22 @@ func New202Response(body io.ReadCloser) Response {
 	}}
 }
 
+// New302Response creates a new response with a statuscode 302
+func New302Response(body io.ReadCloser) Response {
+	return Response{Response: http.Response{
+		StatusCode: 302,
+		Body:       populateBody(body),
+	}}
+}
+
+// New400Response creates a new response with a statuscode 400
+func New400Response(body io.ReadCloser) Response {
+	return Response{Response: http.Response{
+		StatusCode: 400,
+		Body:       populateBody(body),
+	}}
+}
+
 // New404Response creates a new response with a statuscode 404
 func New404Response(body io.ReadCloser) Response {
 	return Response{Response: http.Response{
@@ -101,6 +117,22 @@ func New409Response(body io.ReadCloser) Response {
 func New500Response(body io.ReadCloser) Response {
 	return Response{Response: http.Response{
 		StatusCode: 500,
+		Body:       populateBody(body),
+	}}
+}
+
+// New501Response creates a new response with a statuscode 501
+func New501Response(body io.ReadCloser) Response {
+	return Response{Response: http.Response{
+		StatusCode: 501,
+		Body:       populateBody(body),
+	}}
+}
+
+// New502Response creates a new response with a statuscode 502
+func New502Response(body io.ReadCloser) Response {
+	return Response{Response: http.Response{
+		StatusCode: 502,
 		Body:       populateBody(body),
 	}}
 }
@@ -138,6 +170,28 @@ func New202ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Re
 	}
 }
 
+// New302ResponseAssertion creates a new response with request assertion and a statuscode 302
+func New302ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Response {
+	return Response{
+		Response: http.Response{
+			StatusCode: 302,
+			Body:       populateBody(body),
+		},
+		Assert: assertion,
+	}
+}
+
+// New400ResponseAssertion creates a new response with request assertion and a statuscode 400
+func New400ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Response {
+	return Response{
+		Response: http.Response{
+			StatusCode: 400,
+			Body:       populateBody(body),
+		},
+		Assert: assertion,
+	}
+}
+
 // New404ResponseAssertion creates a new response with request assertion and a statuscode 404
 func New404ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Response {
 	return Response{
@@ -165,6 +219,28 @@ func New500ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Re
 	return Response{
 		Response: http.Response{
 			StatusCode: 500,
+			Body:       populateBody(body),
+		},
+		Assert: assertion,
+	}
+}
+
+// New501ResponseAssertion creates a new response with request assertion and a statuscode 501
+func New501ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Response {
+	return Response{
+		Response: http.Response{
+			StatusCode: 501,
+			Body:       populateBody(body),
+		},
+		Assert: assertion,
+	}
+}
+
+// New502ResponseAssertion creates a new response with request assertion and a statuscode 502
+func New502ResponseAssertion(assertion *RequestAssertion, body io.ReadCloser) Response {
+	return Response{
+		Response: http.Response{
+			StatusCode: 502,
 			Body:       populateBody(body),
 		},
 		Assert: assertion,

--- a/pkg/api/mock/response_test.go
+++ b/pkg/api/mock/response_test.go
@@ -150,6 +150,82 @@ func TestNew202Response(t *testing.T) {
 	}
 }
 
+func TestNew302Response(t *testing.T) {
+	bodyBuffer := NewStringBody("302")
+	type args struct {
+		body io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 302",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 302,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 302 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 302,
+				Body:       bodyBuffer,
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New302Response(tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New302Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew400Response(t *testing.T) {
+	bodyBuffer := NewStringBody("400")
+	type args struct {
+		body io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 400",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 400,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 400 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 400,
+				Body:       bodyBuffer,
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New400Response(tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New400Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNew404Response(t *testing.T) {
 	bodyBuffer := NewStringBody("404")
 	type args struct {
@@ -259,6 +335,82 @@ func TestNew500Response(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := New500Response(tt.args.body); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("New500Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew501Response(t *testing.T) {
+	bodyBuffer := NewStringBody("501")
+	type args struct {
+		body io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 501",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 501,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 501 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 501,
+				Body:       bodyBuffer,
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New501Response(tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New501Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew502Response(t *testing.T) {
+	bodyBuffer := NewStringBody("502")
+	type args struct {
+		body io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 502",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 502,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 502 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 502,
+				Body:       bodyBuffer,
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New502Response(tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New502Response() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -423,6 +575,112 @@ func TestNew202ResponseAssertion(t *testing.T) {
 	}
 }
 
+func TestNew302ResponseAssertion(t *testing.T) {
+	bodyBuffer := NewStringBody("302")
+	type args struct {
+		assertion *RequestAssertion
+		body      io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 302",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 302,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 302 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 302,
+				Body:       bodyBuffer,
+			}},
+		},
+		{
+			name: "Returns statuscode 302 with body and request assertion",
+			args: args{
+				assertion: mockRequestAssertion,
+				body:      bodyBuffer,
+			},
+			want: Response{
+				Response: http.Response{
+					StatusCode: 302,
+					Body:       bodyBuffer,
+				},
+				Assert: mockRequestAssertion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New302ResponseAssertion(tt.args.assertion, tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New302Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew400ResponseAssertion(t *testing.T) {
+	bodyBuffer := NewStringBody("400")
+	type args struct {
+		assertion *RequestAssertion
+		body      io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 400",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 400,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 400 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 400,
+				Body:       bodyBuffer,
+			}},
+		},
+		{
+			name: "Returns statuscode 400 with body and request assertion",
+			args: args{
+				assertion: mockRequestAssertion,
+				body:      bodyBuffer,
+			},
+			want: Response{
+				Response: http.Response{
+					StatusCode: 400,
+					Body:       bodyBuffer,
+				},
+				Assert: mockRequestAssertion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New400ResponseAssertion(tt.args.assertion, tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New400Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNew404ResponseAssertion(t *testing.T) {
 	bodyBuffer := NewStringBody("404")
 	type args struct {
@@ -577,6 +835,112 @@ func TestNew500ResponseAssertion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := New500ResponseAssertion(tt.args.assertion, tt.args.body); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("New500Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew501ResponseAssertion(t *testing.T) {
+	bodyBuffer := NewStringBody("501")
+	type args struct {
+		assertion *RequestAssertion
+		body      io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 501",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 501,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 501 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 501,
+				Body:       bodyBuffer,
+			}},
+		},
+		{
+			name: "Returns statuscode 501 with body and request assertion",
+			args: args{
+				assertion: mockRequestAssertion,
+				body:      bodyBuffer,
+			},
+			want: Response{
+				Response: http.Response{
+					StatusCode: 501,
+					Body:       bodyBuffer,
+				},
+				Assert: mockRequestAssertion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New501ResponseAssertion(tt.args.assertion, tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New501Response() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNew502ResponseAssertion(t *testing.T) {
+	bodyBuffer := NewStringBody("502")
+	type args struct {
+		assertion *RequestAssertion
+		body      io.ReadCloser
+	}
+	tests := []struct {
+		name string
+		args args
+		want Response
+	}{
+		{
+			name: "Returns statuscode 502",
+			args: args{},
+			want: Response{Response: http.Response{
+				StatusCode: 502,
+				Body:       NewStringBody(""),
+			}},
+		},
+		{
+			name: "Returns statuscode 502 with body",
+			args: args{
+				body: bodyBuffer,
+			},
+			want: Response{Response: http.Response{
+				StatusCode: 502,
+				Body:       bodyBuffer,
+			}},
+		},
+		{
+			name: "Returns statuscode 502 with body and request assertion",
+			args: args{
+				assertion: mockRequestAssertion,
+				body:      bodyBuffer,
+			},
+			want: Response{
+				Response: http.Response{
+					StatusCode: 502,
+					Body:       bodyBuffer,
+				},
+				Assert: mockRequestAssertion,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New502ResponseAssertion(tt.args.assertion, tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New502Response() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
It adds missing HTTP responses (`302`, `400`, `501`, `502`) to Mock API client.

## Description
To be able to run acceptance tests in TF ElasticCloud provider, we need to mock API client and some HTTP responses are missing.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

---

Metas: https://github.com/elastic/cloud/issues/93118 https://github.com/elastic/cloud/issues/93122
Rel: https://github.com/elastic/cloud/issues/93121