### PR TITLE
Update Codeowners to the cloud applications team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repository.
-*       @elastic/cloud-applications
+*       @elastic/cloud-applications-solutions 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repository.
-*       @elastic/cloud-delivery
+*       @elastic/cloud-applications


### PR DESCRIPTION
There's been a formal agreement to move the SDK over to the applications team and they are actively working on it and unfortunately it requires Delivery to approve PRs.  With this change, Delivery will no longer be a blocker. 

@pcsanwald @StaceyKingPoling heads up for awareness.  
