### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # These owners will be the default owners for everything in
 # the repository.
 
+* @elastic/cloud-applications-solutions


### PR DESCRIPTION
Re-adding applications/solutions as the owner here.

~Before merging, we'll update the repo settings such that code owners are not a required reviewer, mirroring the settings in Cloud. This should setup code owners as a notification channel, and a default reviewer for incoming PRs, but not present a roadblock for other contributors with write permissions.~

This has been done.