### PR TITLE
Keep all Elasticsearch topologies when building update request.

### DIFF
--- a/pkg/api/deploymentapi/testdata/apm_update.json
+++ b/pkg/api/deploymentapi/testdata/apm_update.json
@@ -52,6 +52,49 @@
                 "value": 1024
               },
               "zone_count": 2
+            },
+            {
+              "elasticsearch": {},
+              "instance_configuration_id": "gcp.coordinating.1",
+              "node_type": {
+                "data": false,
+                "ingest": true,
+                "master": false
+              },
+              "size": {
+                "resource": "memory",
+                "value": 0
+              },
+              "zone_count": 2
+            },
+            {
+              "elasticsearch": {},
+              "instance_configuration_id": "gcp.master.1",
+              "node_type": {
+                "data": false,
+                "ingest": false,
+                "master": true
+              },
+              "size": {
+                "resource": "memory",
+                "value": 0
+              },
+              "zone_count": 3
+            },
+            {
+              "elasticsearch": {},
+              "instance_configuration_id": "gcp.ml.1",
+              "node_type": {
+                "data": false,
+                "ingest": false,
+                "master": false,
+                "ml": true
+              },
+              "size": {
+                "resource": "memory",
+                "value": 0
+              },
+              "zone_count": 1
             }
           ],
           "deployment_template": {

--- a/pkg/api/deploymentapi/testdata/appsearch_update.json
+++ b/pkg/api/deploymentapi/testdata/appsearch_update.json
@@ -61,6 +61,20 @@
                 "value": 1024
               },
               "zone_count": 1
+            },
+            {
+              "elasticsearch": {},
+              "instance_configuration_id": "gcp.master.1",
+              "node_type": {
+                "data": false,
+                "ingest": false,
+                "master": true
+              },
+              "size": {
+                "resource": "memory",
+                "value": 0
+              },
+              "zone_count": 3
             }
           ],
           "deployment_template": {

--- a/pkg/api/deploymentapi/testdata/enterprise_search_update.json
+++ b/pkg/api/deploymentapi/testdata/enterprise_search_update.json
@@ -22,6 +22,20 @@
                 "value": 1024
               },
               "zone_count": 1
+            },
+            {
+              "elasticsearch": {},
+              "instance_configuration_id": "gcp.master.1",
+              "node_type": {
+                "data": false,
+                "ingest": false,
+                "master": true
+              },
+              "size": {
+                "resource": "memory",
+                "value": 0
+              },
+              "zone_count": 3
             }
           ],
           "deployment_template": {

--- a/pkg/api/deploymentapi/testdata/logging_metrics_legacy_kibana_update.json
+++ b/pkg/api/deploymentapi/testdata/logging_metrics_legacy_kibana_update.json
@@ -41,6 +41,103 @@
                                 "value": 16384
                             },
                             "zone_count": 3
+                        },
+                        {
+                            "elasticsearch": {
+                                "system_settings": {
+                                    "auto_create_index": true,
+                                    "destructive_requires_name": false,
+                                    "enable_close_index": false,
+                                    "monitoring_collection_interval": -1,
+                                    "monitoring_history_duration": "7d",
+                                    "reindex_whitelist": [],
+                                    "scripting": {
+                                        "inline": {
+                                            "enabled": true
+                                        },
+                                        "stored": {
+                                            "enabled": true
+                                        }
+                                    },
+                                    "use_disk_threshold": true
+                                }
+                            },
+                            "instance_configuration_id": "coordinating",
+                            "node_type": {
+                                "data": false,
+                                "ingest": true,
+                                "master": false
+                            },
+                            "size": {
+                                "resource": "memory",
+                                "value": 0
+                            },
+                            "zone_count": 1
+                        },
+                        {
+                            "elasticsearch": {
+                                "system_settings": {
+                                    "auto_create_index": true,
+                                    "destructive_requires_name": false,
+                                    "enable_close_index": false,
+                                    "monitoring_collection_interval": -1,
+                                    "monitoring_history_duration": "7d",
+                                    "reindex_whitelist": [],
+                                    "scripting": {
+                                        "inline": {
+                                            "enabled": true
+                                        },
+                                        "stored": {
+                                            "enabled": true
+                                        }
+                                    },
+                                    "use_disk_threshold": true
+                                }
+                            },
+                            "instance_configuration_id": "master",
+                            "node_type": {
+                                "data": false,
+                                "ingest": false,
+                                "master": true
+                            },
+                            "size": {
+                                "resource": "memory",
+                                "value": 0
+                            },
+                            "zone_count": 1
+                        },
+                        {
+                            "elasticsearch": {
+                                "system_settings": {
+                                    "auto_create_index": true,
+                                    "destructive_requires_name": false,
+                                    "enable_close_index": false,
+                                    "monitoring_collection_interval": -1,
+                                    "monitoring_history_duration": "7d",
+                                    "reindex_whitelist": [],
+                                    "scripting": {
+                                        "inline": {
+                                            "enabled": true
+                                        },
+                                        "stored": {
+                                            "enabled": true
+                                        }
+                                    },
+                                    "use_disk_threshold": true
+                                }
+                            },
+                            "instance_configuration_id": "ml",
+                            "node_type": {
+                                "data": false,
+                                "ingest": false,
+                                "master": false,
+                                "ml": true
+                            },
+                            "size": {
+                                "resource": "memory",
+                                "value": 0
+                            },
+                            "zone_count": 1
                         }
                     ],
                     "deployment_template": {

--- a/pkg/api/deploymentapi/testdata/observability_update.json
+++ b/pkg/api/deploymentapi/testdata/observability_update.json
@@ -25,14 +25,28 @@
                         },
                         {
                             "elasticsearch": {},
+                            "instance_configuration_id": "gcp.master.1",
+                            "node_type": {
+                                "data": false,
+                                "ingest": false,
+                                "master": true
+                            },
+                            "size": {
+                                "resource": "memory",
+                                "value": 0
+                            },
+                            "zone_count": 3
+                        },
+                        {
+                            "elasticsearch": {},
                             "instance_configuration_id": "gcp.data.highio.1",
-                            "memory_per_node": 2048,
                             "node_type": {
                                 "data": true,
                                 "ingest": true,
                                 "master": true
                             },
-                            "zone_count": 1
+                            "zone_count": 1,
+                            "memory_per_node": 2048
                         }
                     ],
                     "deployment_template": {

--- a/pkg/api/deploymentapi/update_payload.go
+++ b/pkg/api/deploymentapi/update_payload.go
@@ -95,14 +95,6 @@ func parseElasticsearchGetResponse(r *models.ElasticsearchResourceInfo) (payload
 		r.Info.Settings.Metadata = nil
 	}
 
-	var ct = make([]*models.ElasticsearchClusterTopologyElement, 0, len(plan.Plan.ClusterTopology))
-	for _, t := range plan.Plan.ClusterTopology {
-		if t.MemoryPerNode > 0 || !nilOZeroToplogySize(t.Size) {
-			ct = append(ct, t)
-		}
-	}
-	plan.Plan.ClusterTopology = ct
-
 	return &models.ElasticsearchPayload{
 		DisplayName: *r.Info.ClusterName,
 		RefID:       r.RefID,


### PR DESCRIPTION
The response from the API does already contain all topologies, but they were removed when building the update request. Now we simply keep all elements as the API returns them.

This is mainly needed when autoscaling is enabled. In that case the update request must contain all existing topology elements to validate correctly.

<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Fixes an `ecctl` issue: https://github.com/elastic/ecctl/issues/596

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
