### PR TITLE
fix(runtime): add billing to globalPath

### DIFF
--- a/pkg/api/client_runtime.go
+++ b/pkg/api/client_runtime.go
@@ -61,6 +61,7 @@ var globalPath = map[string]bool{
 	"stack":       false,
 	"user":        true,
 	"users":       true,
+	"billing":     true,
 }
 
 type newRuntimeFunc func(region string) *runtimeclient.Runtime

--- a/pkg/api/client_runtime_test.go
+++ b/pkg/api/client_runtime_test.go
@@ -224,6 +224,17 @@ func TestCloudClientRuntime_getRuntime(t *testing.T) {
 			}},
 			err: errors.New("the requested operation requires a region but none has been set"),
 		},
+		{
+			name: "/billing operation uses the regionless path",
+			fields: fields{
+				newRegionRuntime: mocknewRuntimeFunc,
+				runtime:          regionless,
+			},
+			args: args{op: &runtime.ClientOperation{
+				PathPattern: "/billing/costs",
+			}},
+			want: &runtimeclient.Runtime{BasePath: "/api/v1/"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Billing path should be region-less
## Description
<!--- Describe your changes in detail. -->
I have just added `billing` to `globaPath` to return regionLess runtime.
## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I wanted to call `GetCostsItemsByDeployment` but I was getting the error
```
the requested operation requires a region but none has been set
```
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
