### PR TITLE
[1.12] snaprepoapi: Add PathStyleAccess field to S3Config (#426)

### DIFF
--- a/pkg/api/platformapi/snaprepoapi/s3_config.go
+++ b/pkg/api/platformapi/snaprepoapi/s3_config.go
@@ -88,8 +88,8 @@ func ParseS3Config(input io.Reader) (S3Config, error) {
 
 // S3Config is used to configure an S3 snapshot repository
 // Full list of settings in the Elasticsearch official documentation:
-// https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-repository.html
-// https://www.elastic.co/guide/en/elasticsearch/plugins/current/repository-s3-client.html
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/repository-s3.html#repository-s3-repository
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/repository-s3.html#repository-s3-client
 // nolint
 type S3Config struct {
 	// Required settings
@@ -115,6 +115,7 @@ type S3Config struct {
 	Timeout         time.Duration `json:"timeout,omitempty"`
 	MaxRetries      int           `json:"max_retries,omitempty"`
 	ThrottleRetries bool          `json:"throttle_retries,omitempty"`
+	PathStyleAccess bool          `json:"path_style_access,omitempty"`
 }
 
 // S3TypeConfig is used by the text formatter to wrwap the S3 config with the

--- a/pkg/api/platformapi/snaprepoapi/s3_config_test.go
+++ b/pkg/api/platformapi/snaprepoapi/s3_config_test.go
@@ -117,6 +117,7 @@ func TestS3Config_Validate(t *testing.T) {
 		Compress             bool
 		ServerSideEncryption bool
 		ThrottleRetries      bool
+		PathStyleAccess      bool
 	}
 	tests := []struct {
 		name    string
@@ -191,6 +192,7 @@ func TestS3Config_Validate(t *testing.T) {
 				Timeout:              tt.fields.Timeout,
 				MaxRetries:           tt.fields.MaxRetries,
 				ThrottleRetries:      tt.fields.ThrottleRetries,
+				PathStyleAccess:      tt.fields.PathStyleAccess,
 			}
 			if err := c.Validate(); (err != nil) != tt.wantErr {
 				t.Errorf("S3Config.Validate() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.12`:
 - [snaprepoapi: Add PathStyleAccess field to S3Config (#426)](https://github.com/elastic/cloud-sdk-go/pull/426)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)