### PR TITLE
fix: support allocator down for vacating cluster resources

### DIFF
--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -268,7 +268,7 @@ func addAllocatorMovesToPool(params addAllocatorMovesToPoolParams) ([]pool.Valid
 }
 
 func newVacateClusterParams(params addAllocatorMovesToPoolParams, id, kind string) *VacateClusterParams {
-	return &VacateClusterParams{
+	clusterParams := VacateClusterParams{
 		API:                 params.VacateParams.API,
 		ID:                  params.ID,
 		Kind:                kind,
@@ -284,6 +284,12 @@ func newVacateClusterParams(params addAllocatorMovesToPoolParams, id, kind strin
 		MoveOnly:            params.VacateParams.MoveOnly,
 		PlanOverrides:       params.VacateParams.PlanOverrides,
 	}
+
+	if params.VacateParams.AllocatorDown != nil {
+		clusterParams.AllocatorDown = params.VacateParams.AllocatorDown
+	}
+
+	return &clusterParams
 }
 
 // VacateClusterInPool vacates a resource from an allocator, complying

--- a/pkg/api/platformapi/allocatorapi/vacate_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_test.go
@@ -845,6 +845,41 @@ func TestVacateCluster(t *testing.T) {
 			),
 		},
 		{
+			name: "Succeeds with an allocator down",
+			args: args{
+				buf: new(bytes.Buffer),
+				params: &VacateClusterParams{
+					ID:             "someID",
+					Region:         "us-east-1",
+					ClusterID:      "3ee11eb40eda22cac0cce259625c6734",
+					Kind:           "elasticsearch",
+					Output:         new(output.Device),
+					TrackFrequency: time.Nanosecond,
+					OutputFormat:   "text",
+					MaxPollRetries: 1,
+					AllocatorDown:  ec.Bool(true),
+					API: discardResponses(newElasticsearchVacateMoveAllocatorDown(t, "someID", vacateCaseClusterConfig{
+						ID: "3ee11eb40eda22cac0cce259625c6734",
+						steps: [][]*models.ClusterPlanStepInfo{
+							{
+								newPlanStep("step1", "success"),
+								newPlanStep("step2", "pending"),
+							},
+						},
+						plan: []*models.ClusterPlanStepInfo{
+							newPlanStep("step1", "success"),
+							newPlanStep("step2", "success"),
+							newPlanStep("plan-completed", "success"),
+						},
+					}, "us-east-1")),
+				},
+			},
+			want: newOutputResponses(
+				`Deployment [DISCOVERED_DEPLOYMENT_ID] - [Elasticsearch][3ee11eb40eda22cac0cce259625c6734]: running step "step2" (Plan duration )...`,
+				"\x1b[92;mDeployment [DISCOVERED_DEPLOYMENT_ID] - [Elasticsearch][3ee11eb40eda22cac0cce259625c6734]: finished running all the plan steps\x1b[0m (Total plan duration )",
+			),
+		},
+		{
 			name: "Succeeds with an elasticsearch cluster with no tracking",
 			args: args{
 				buf: new(bytes.Buffer),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
## Description
<!--- Describe your changes in detail. -->

  - The actual vacate request that was being used on cluster resources did not propagate down the flag being set for "VacateParams"
  - This leads to a request that ultimately does not include the query param when performing the vacate

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Unable to pass `--allocator-down true` and have it be respected from ecctl's perspective.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

UTs and will validate with a local version of ecctl (**TODO**)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed (existing test failing on master)
