### PR TITLE
Handle empty instance_config_version in topology elements

### DIFF
--- a/cmd/generator/cloudspec/spec_modifier.go
+++ b/cmd/generator/cloudspec/spec_modifier.go
@@ -70,6 +70,36 @@ func Modify(cloudSpec *spec.Swagger) {
 				cloudSpec.Definitions[k].Properties[kk] = prop
 			}
 
+			if k == "ApmTopologyElement" && kk == "instance_configuration_version" {
+				prop.AddExtension(nullableKey, true)
+				cloudSpec.Definitions[k].Properties[kk] = prop
+			}
+
+			if k == "AppSearchTopologyElement" && kk == "instance_configuration_version" {
+				prop.AddExtension(nullableKey, true)
+				cloudSpec.Definitions[k].Properties[kk] = prop
+			}
+
+			if k == "ElasticsearchClusterTopologyElement" && kk == "instance_configuration_version" {
+				prop.AddExtension(nullableKey, true)
+				cloudSpec.Definitions[k].Properties[kk] = prop
+			}
+
+			if k == "EnterpriseSearchTopologyElement" && kk == "instance_configuration_version" {
+				prop.AddExtension(nullableKey, true)
+				cloudSpec.Definitions[k].Properties[kk] = prop
+			}
+
+			if k == "IntegrationsServerTopologyElement" && kk == "instance_configuration_version" {
+				prop.AddExtension(nullableKey, true)
+				cloudSpec.Definitions[k].Properties[kk] = prop
+			}
+
+			if k == "KibanaClusterTopologyElement" && kk == "instance_configuration_version" {
+				prop.AddExtension(nullableKey, true)
+				cloudSpec.Definitions[k].Properties[kk] = prop
+			}
+
 			if k == "ElasticsearchConfiguration" {
 				if kk == "enabled_built_in_plugins" ||
 					kk == "user_bundles" ||

--- a/pkg/models/apm_topology_element.go
+++ b/pkg/models/apm_topology_element.go
@@ -42,7 +42,7 @@ type ApmTopologyElement struct {
 	InstanceConfigurationID string `json:"instance_configuration_id,omitempty"`
 
 	// The version of the Instance Configuration Id. If it is unset, the meaning depends on read vs writes. For deployment reads, it is equivalent to version 0 (or the IC is unversioned); for deployment creates and deployment template use, it is equivalent to 'the latest version'; and for deployment updates, it is equivalent to 'retain the current version'.
-	InstanceConfigurationVersion int32 `json:"instance_configuration_version,omitempty"`
+	InstanceConfigurationVersion *int32 `json:"instance_configuration_version,omitempty"`
 
 	// size
 	Size *TopologySize `json:"size,omitempty"`

--- a/pkg/models/app_search_topology_element.go
+++ b/pkg/models/app_search_topology_element.go
@@ -42,7 +42,7 @@ type AppSearchTopologyElement struct {
 	InstanceConfigurationID string `json:"instance_configuration_id,omitempty"`
 
 	// The version of the Instance Configuration Id. If it is unset, the meaning depends on read vs writes. For deployment reads, it is equivalent to version 0 (or the IC is unversioned); for deployment creates and deployment template use, it is equivalent to 'the latest version'; and for deployment updates, it is equivalent to 'retain the current version'.
-	InstanceConfigurationVersion int32 `json:"instance_configuration_version,omitempty"`
+	InstanceConfigurationVersion *int32 `json:"instance_configuration_version,omitempty"`
 
 	// Defines the AppSearch node type
 	NodeType *AppSearchNodeTypes `json:"node_type,omitempty"`

--- a/pkg/models/elasticsearch_cluster_topology_element.go
+++ b/pkg/models/elasticsearch_cluster_topology_element.go
@@ -60,7 +60,7 @@ type ElasticsearchClusterTopologyElement struct {
 	InstanceConfigurationID string `json:"instance_configuration_id,omitempty"`
 
 	// The version of the Instance Configuration Id. If it is unset, the meaning depends on read vs writes. For deployment reads, it is equivalent to version 0 (or the IC is unversioned); for deployment creates and deployment template use, it is equivalent to 'the latest version'; and for deployment updates, it is equivalent to 'retain the current version'.
-	InstanceConfigurationVersion int32 `json:"instance_configuration_version,omitempty"`
+	InstanceConfigurationVersion *int32 `json:"instance_configuration_version,omitempty"`
 
 	// The memory capacity in MB for each node of this type built in each zone.
 	MemoryPerNode int32 `json:"memory_per_node,omitempty"`

--- a/pkg/models/enterprise_search_topology_element.go
+++ b/pkg/models/enterprise_search_topology_element.go
@@ -45,7 +45,7 @@ type EnterpriseSearchTopologyElement struct {
 	InstanceConfigurationID string `json:"instance_configuration_id,omitempty"`
 
 	// The version of the Instance Configuration Id. If it is unset, the meaning depends on read vs writes. For deployment reads, it is equivalent to version 0 (or the IC is unversioned); for deployment creates and deployment template use, it is equivalent to 'the latest version'; and for deployment updates, it is equivalent to 'retain the current version'.
-	InstanceConfigurationVersion int32 `json:"instance_configuration_version,omitempty"`
+	InstanceConfigurationVersion *int32 `json:"instance_configuration_version,omitempty"`
 
 	// memory per node
 	MemoryPerNode interface{} `json:"memory_per_node,omitempty"`

--- a/pkg/models/integrations_server_topology_element.go
+++ b/pkg/models/integrations_server_topology_element.go
@@ -39,7 +39,7 @@ type IntegrationsServerTopologyElement struct {
 	InstanceConfigurationID string `json:"instance_configuration_id,omitempty"`
 
 	// The version of the Instance Configuration Id. If it is unset, the meaning depends on read vs writes. For deployment reads, it is equivalent to version 0 (or the IC is unversioned); for deployment creates and deployment template use, it is equivalent to 'the latest version'; and for deployment updates, it is equivalent to 'retain the current version'.
-	InstanceConfigurationVersion int32 `json:"instance_configuration_version,omitempty"`
+	InstanceConfigurationVersion *int32 `json:"instance_configuration_version,omitempty"`
 
 	// integrations server
 	IntegrationsServer *IntegrationsServerConfiguration `json:"integrations_server,omitempty"`

--- a/pkg/models/kibana_cluster_topology_element.go
+++ b/pkg/models/kibana_cluster_topology_element.go
@@ -39,7 +39,7 @@ type KibanaClusterTopologyElement struct {
 	InstanceConfigurationID string `json:"instance_configuration_id,omitempty"`
 
 	// The version of the Instance Configuration Id. If it is unset, the meaning depends on read vs writes. For deployment reads, it is equivalent to version 0 (or the IC is unversioned); for deployment creates and deployment template use, it is equivalent to 'the latest version'; and for deployment updates, it is equivalent to 'retain the current version'.
-	InstanceConfigurationVersion int32 `json:"instance_configuration_version,omitempty"`
+	InstanceConfigurationVersion *int32 `json:"instance_configuration_version,omitempty"`
 
 	// kibana
 	Kibana *KibanaConfiguration `json:"kibana,omitempty"`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
This changes the type of the `instance_configuration_version` field to `*int32` for all topology elements and marks the fields as nullable.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
Rel: https://elasticco.atlassian.net/browse/CP-5181

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can't set `instance_configuration_version` to `0` because it will be considered as an empty value and it will be omitted during JSON marshalling. 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
