### PR TITLE
Remove workflow updating master.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,32 +56,3 @@ jobs:
           new_branch: ${{ steps.get_branch.outputs.BRANCH }}
           author_name: elasticcloudclients
           author_email: elasticcloudclients@elastic.co
-
-  bump-minor-version:
-    name: Bump main version
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: master
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.19
-        id: go
-
-      - name: Bump main version
-        run: make minor; git diff
-
-      - name: Commit changes to main
-        uses: EndBug/add-and-commit@v9
-        with:
-          default_author: user_info
-          message: 'Update minor version'
-          branch: master
-          author_name: elasticcloudclients
-          author_email: elasticcloudclients@elastic.co


### PR DESCRIPTION
Due to security restrictions the workflow is not allowed to push directly to master and therefore will fail every time.

So I think it makes sense to just remove it and to update the VERSION manually.

Example action: https://github.com/elastic/cloud-sdk-go/actions/runs/9060730704/job/24891035927