### PR TITLE
Change deployment-alias type to *string.

### DIFF
--- a/cmd/generator/cloudspec/spec_modifier.go
+++ b/cmd/generator/cloudspec/spec_modifier.go
@@ -100,6 +100,19 @@ func Modify(cloudSpec *spec.Swagger) {
 				cloudSpec.Definitions[k].Properties[kk] = prop
 			}
 
+			addExtension := func(model string, field string, key string, value interface{}) {
+				if k == model && kk == field {
+					prop.AddExtension(key, value)
+					cloudSpec.Definitions[k].Properties[kk] = prop
+				}
+			}
+			addExtension("DeploymentGetResponse", "alias", nullableKey, true)
+			addExtension("DeploymentSearchResponse", "alias", nullableKey, true)
+			addExtension("DeploymentCreateRequest", "alias", nullableKey, true)
+			addExtension("DeploymentCreateResponse", "alias", nullableKey, true)
+			addExtension("DeploymentUpdateRequest", "alias", nullableKey, true)
+			addExtension("DeploymentUpdateResponse", "alias", nullableKey, true)
+
 			if k == "ElasticsearchConfiguration" {
 				if kk == "enabled_built_in_plugins" ||
 					kk == "user_bundles" ||

--- a/pkg/models/deployment_create_request.go
+++ b/pkg/models/deployment_create_request.go
@@ -36,7 +36,7 @@ import (
 type DeploymentCreateRequest struct {
 
 	// A user-defined alias to use in place of Cluster IDs for user-friendly URLs
-	Alias string `json:"alias,omitempty"`
+	Alias *string `json:"alias,omitempty"`
 
 	// Additional information about this deployment
 	Metadata *DeploymentCreateMetadata `json:"metadata,omitempty"`

--- a/pkg/models/deployment_create_response.go
+++ b/pkg/models/deployment_create_response.go
@@ -38,7 +38,7 @@ import (
 type DeploymentCreateResponse struct {
 
 	// A user-defined deployment alias for user-friendly resource URLs
-	Alias string `json:"alias,omitempty"`
+	Alias *string `json:"alias,omitempty"`
 
 	// Whether or not the deployment was freshly created
 	// Required: true

--- a/pkg/models/deployment_get_response.go
+++ b/pkg/models/deployment_get_response.go
@@ -38,7 +38,7 @@ import (
 type DeploymentGetResponse struct {
 
 	// A user-defined deployment alias for user-friendly resource URLs
-	Alias string `json:"alias,omitempty"`
+	Alias *string `json:"alias,omitempty"`
 
 	// Whether the deployment is overall healthy or not (one or more of the resource info subsections will have healthy: false)
 	// Required: true

--- a/pkg/models/deployment_search_response.go
+++ b/pkg/models/deployment_search_response.go
@@ -37,7 +37,7 @@ import (
 type DeploymentSearchResponse struct {
 
 	// A user-defined deployment alias for user-friendly resource URLs
-	Alias string `json:"alias,omitempty"`
+	Alias *string `json:"alias,omitempty"`
 
 	// Whether the deployment is overall healthy or not (one or more of the resource info subsections will have healthy: false)
 	// Required: true

--- a/pkg/models/deployment_update_request.go
+++ b/pkg/models/deployment_update_request.go
@@ -37,7 +37,7 @@ import (
 type DeploymentUpdateRequest struct {
 
 	// A user-defined alias to use in place of Cluster IDs for user-friendly URLs
-	Alias string `json:"alias,omitempty"`
+	Alias *string `json:"alias,omitempty"`
 
 	// Any new information about the current deployment object. If there is no new information the value is unchanged.
 	Metadata *DeploymentUpdateMetadata `json:"metadata,omitempty"`

--- a/pkg/models/deployment_update_response.go
+++ b/pkg/models/deployment_update_response.go
@@ -38,7 +38,7 @@ import (
 type DeploymentUpdateResponse struct {
 
 	// A user-defined alias to use in place of ResourceIds for user-friendly resource URLs
-	Alias string `json:"alias,omitempty"`
+	Alias *string `json:"alias,omitempty"`
 
 	// Backend diagnostics. Sent if validation is requested.
 	Diagnostics *DeploymentDiagnostics `json:"diagnostics,omitempty"`


### PR DESCRIPTION
The deployment-alias field has the following behavior:
- Not added in request -> Don't update field
- Set to empty value -> Remove deployment alias
- Set to non-empty value -> Set alias to that value

So with the old spec, it wasn't possible to remove the alias after it was set, as due to `omitempty` an empty value is not added to the request. This is now possible.

<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
