### PR TITLE
Set organizations as global to skip region checks

### DIFF
--- a/pkg/api/client_runtime.go
+++ b/pkg/api/client_runtime.go
@@ -53,15 +53,16 @@ var DefaultBasePath = client.DefaultBasePath
 // Strictly, there's no need for a `"key":false` to be present in the map, but
 // it does make it explicit and nicer to maintain.
 var globalPath = map[string]bool{
-	"clusters":    false,
-	"comments":    false,
-	"deployments": true,
-	"phone-home":  true,
-	"platform":    false,
-	"stack":       false,
-	"user":        true,
-	"users":       true,
-	"billing":     true,
+	"clusters":      false,
+	"comments":      false,
+	"deployments":   true,
+	"phone-home":    true,
+	"platform":      false,
+	"stack":         false,
+	"user":          true,
+	"users":         true,
+	"billing":       true,
+	"organizations": true,
 }
 
 type newRuntimeFunc func(region string) *runtimeclient.Runtime

--- a/pkg/api/client_runtime_test.go
+++ b/pkg/api/client_runtime_test.go
@@ -235,6 +235,17 @@ func TestCloudClientRuntime_getRuntime(t *testing.T) {
 			}},
 			want: &runtimeclient.Runtime{BasePath: "/api/v1"},
 		},
+		{
+			name: "/billing operation uses the regionless path",
+			fields: fields{
+				newRegionRuntime: mocknewRuntimeFunc,
+				runtime:          regionless,
+			},
+			args: args{op: &runtime.ClientOperation{
+				PathPattern: "/organizations/1234123",
+			}},
+			want: &runtimeclient.Runtime{BasePath: "/api/v1"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/api/client_runtime_test.go
+++ b/pkg/api/client_runtime_test.go
@@ -236,7 +236,7 @@ func TestCloudClientRuntime_getRuntime(t *testing.T) {
 			want: &runtimeclient.Runtime{BasePath: "/api/v1"},
 		},
 		{
-			name: "/billing operation uses the regionless path",
+			name: "/organizations operation uses the regionless path",
 			fields: fields{
 				newRegionRuntime: mocknewRuntimeFunc,
 				runtime:          regionless,


### PR DESCRIPTION
Updates the list of global APIs to include the /organizations endpoint.
Avoiding errors like: `the requested operation requires a region but none has been set`