### PR TITLE
Set `saas` endpoint as global to skip region checks

### DIFF
--- a/pkg/api/client_runtime.go
+++ b/pkg/api/client_runtime.go
@@ -63,6 +63,7 @@ var globalPath = map[string]bool{
 	"users":         true,
 	"billing":       true,
 	"organizations": true,
+	"saas":          true,
 }
 
 type newRuntimeFunc func(region string) *runtimeclient.Runtime

--- a/pkg/api/client_runtime_test.go
+++ b/pkg/api/client_runtime_test.go
@@ -246,6 +246,17 @@ func TestCloudClientRuntime_getRuntime(t *testing.T) {
 			}},
 			want: &runtimeclient.Runtime{BasePath: "/api/v1"},
 		},
+		{
+			name: "/saas operation uses the regionless path",
+			fields: fields{
+				newRegionRuntime: mocknewRuntimeFunc,
+				runtime:          regionless,
+			},
+			args: args{op: &runtime.ClientOperation{
+				PathPattern: "/saas/billing/prices",
+			}},
+			want: &runtimeclient.Runtime{BasePath: "/api/v1"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Updates the list of global APIs to include the `/saas` endpoint.

## Related Issues
https://elasticco.atlassian.net/browse/CP-7863

## Motivation and Context
The `/saas/billing/prices` endpoint is a global endpoint that doesn't require the `/regions/$region` prefix. However, if this endpoint isn't added to the global list, trying to use it in the `cloud-cli` code without specifying a region in the context will result in this error `the requested operation requires a region but none has been set`.

## How Has This Been Tested?
Tested using the new `cloud-cli` changes from https://github.com/elastic/cloud-cli/pull/1525, which perform a `GET /saas/billing/prices` request.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
