### PR TITLE
Add new mock client to match responses by endpoint

### DIFF
--- a/pkg/api/mock.go
+++ b/pkg/api/mock.go
@@ -85,3 +85,19 @@ func NewDebugMock(o io.Writer, res ...mock.Response) *API {
 
 	return api
 }
+
+// NewMockMatchingByEndpoint creates a new api.API from a list of Responses, matching by endpoint.
+// Defaults to a dummy APIKey for authentication, which is not checked
+func NewMockMatchingByEndpoint(res map[string][]mock.Response) *API {
+	api, err := NewAPI(Config{
+		Client:     mock.NewMatchingByEndpointClient(res),
+		Host:       mockSchemaHost,
+		AuthWriter: auth.APIKey("dummy"),
+	})
+
+	if err != nil {
+		panic(err)
+	}
+
+	return api
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
Adds a new mock client to match a set of responses per endpoint. The match is done using a regex.

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->
https://elasticco.atlassian.net/browse/CP-7863

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In PR https://github.com/elastic/cloud-cli/pull/1525, I added some unit tests that are currently failing because they're using the default Round Tripper client. This client provides the responses in the order they're defined. However, in those tests we're not sure in which order the requests are executed, because they're performed by different go routines running concurrently. This new client allows to provide a set of responses per endpoint, by specifying an endpoint regex as the key to a map and a set of responses as the value.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
