### PR TITLE
Add ForceMove option on vacate parameters

### DIFF
--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -127,7 +127,7 @@ func moveNodes(id string, params *VacateParams, p *pool.Pool) ([]pool.Validator,
 			WithAllocatorID(id).
 			WithMoveOnly(params.MoveOnly).
 			WithContext(api.WithRegion(context.Background(), params.Region)).
-			WithForceMove(params.ForceMove).
+			//WithForceMove(params.ForceMove).
 			WithValidateOnly(ec.Bool(true)),
 		params.AuthWriter,
 	)
@@ -419,6 +419,7 @@ func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure
 	var moveParams = platform_infrastructure.NewMoveClustersByTypeParams().
 		WithAllocatorID(params.ID).
 		WithAllocatorDown(params.AllocatorDown).
+		WithForceMove(params.ForceMove).
 		WithContext(api.WithRegion(context.Background(), params.Region)).
 		WithBody(req)
 
@@ -656,6 +657,10 @@ func ComputeVacateRequest(pr *models.MoveClustersDetails, resources, to []string
 
 		if overrides.OverrideFailsafe != nil {
 			c.CalculatedPlan.PlanConfiguration.OverrideFailsafe = overrides.OverrideFailsafe
+		}
+
+		if overrides.ForceMove != nil {
+			c.CalculatedPlan.PlanConfiguration.ForceMove = overrides.ForceMove
 		}
 
 		c.CalculatedPlan.PlanConfiguration.PreferredAllocators = to

--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -420,6 +420,7 @@ func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure
 		WithAllocatorID(params.ID).
 		WithAllocatorDown(params.AllocatorDown).
 		WithContext(api.WithRegion(context.Background(), params.Region)).
+		WithForceMove(params.ForceMove).
 		WithBody(req)
 
 	if len(req.ElasticsearchClusters) > 0 {

--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -126,6 +126,7 @@ func moveNodes(id string, params *VacateParams, p *pool.Pool) ([]pool.Validator,
 		platform_infrastructure.NewMoveClustersParams().
 			WithAllocatorID(id).
 			WithMoveOnly(params.MoveOnly).
+			WithForceMove(params.ForceMove).
 			WithContext(api.WithRegion(context.Background(), params.Region)).
 			WithValidateOnly(ec.Bool(true)),
 		params.AuthWriter,
@@ -282,6 +283,7 @@ func newVacateClusterParams(params addAllocatorMovesToPoolParams, id, kind strin
 		Output:              params.VacateParams.Output,
 		OutputFormat:        params.VacateParams.OutputFormat,
 		MoveOnly:            params.VacateParams.MoveOnly,
+		ForceMove:           params.VacateParams.ForceMove,
 		PlanOverrides:       params.VacateParams.PlanOverrides,
 	}
 
@@ -391,6 +393,7 @@ func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure
 		platform_infrastructure.NewMoveClustersParams().
 			WithAllocatorDown(params.AllocatorDown).
 			WithMoveOnly(params.MoveOnly).
+			WithForceMove(params.ForceMove).
 			WithAllocatorID(params.ID).
 			WithContext(api.WithRegion(context.Background(), params.Region)).
 			WithValidateOnly(ec.Bool(true)).

--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -127,6 +127,7 @@ func moveNodes(id string, params *VacateParams, p *pool.Pool) ([]pool.Validator,
 			WithAllocatorID(id).
 			WithMoveOnly(params.MoveOnly).
 			WithContext(api.WithRegion(context.Background(), params.Region)).
+			WithForceMove(params.ForceMove).
 			WithValidateOnly(ec.Bool(true)),
 		params.AuthWriter,
 	)
@@ -282,6 +283,7 @@ func newVacateClusterParams(params addAllocatorMovesToPoolParams, id, kind strin
 		Output:              params.VacateParams.Output,
 		OutputFormat:        params.VacateParams.OutputFormat,
 		MoveOnly:            params.VacateParams.MoveOnly,
+		ForceMove:           params.VacateParams.ForceMove,
 		PlanOverrides:       params.VacateParams.PlanOverrides,
 	}
 
@@ -391,6 +393,7 @@ func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure
 		platform_infrastructure.NewMoveClustersParams().
 			WithAllocatorDown(params.AllocatorDown).
 			WithMoveOnly(params.MoveOnly).
+			WithForceMove(params.ForceMove).
 			WithAllocatorID(params.ID).
 			WithContext(api.WithRegion(context.Background(), params.Region)).
 			WithValidateOnly(ec.Bool(true)).

--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -126,7 +126,6 @@ func moveNodes(id string, params *VacateParams, p *pool.Pool) ([]pool.Validator,
 		platform_infrastructure.NewMoveClustersParams().
 			WithAllocatorID(id).
 			WithMoveOnly(params.MoveOnly).
-			WithForceMove(params.ForceMove).
 			WithContext(api.WithRegion(context.Background(), params.Region)).
 			WithValidateOnly(ec.Bool(true)),
 		params.AuthWriter,
@@ -283,7 +282,6 @@ func newVacateClusterParams(params addAllocatorMovesToPoolParams, id, kind strin
 		Output:              params.VacateParams.Output,
 		OutputFormat:        params.VacateParams.OutputFormat,
 		MoveOnly:            params.VacateParams.MoveOnly,
-		ForceMove:           params.VacateParams.ForceMove,
 		PlanOverrides:       params.VacateParams.PlanOverrides,
 	}
 
@@ -393,7 +391,6 @@ func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure
 		platform_infrastructure.NewMoveClustersParams().
 			WithAllocatorDown(params.AllocatorDown).
 			WithMoveOnly(params.MoveOnly).
-			WithForceMove(params.ForceMove).
 			WithAllocatorID(params.ID).
 			WithContext(api.WithRegion(context.Background(), params.Region)).
 			WithValidateOnly(ec.Bool(true)).

--- a/pkg/api/platformapi/allocatorapi/vacate.go
+++ b/pkg/api/platformapi/allocatorapi/vacate.go
@@ -420,7 +420,6 @@ func newMoveClusterParams(params *VacateClusterParams) (*platform_infrastructure
 		WithAllocatorID(params.ID).
 		WithAllocatorDown(params.AllocatorDown).
 		WithContext(api.WithRegion(context.Background(), params.Region)).
-		WithForceMove(params.ForceMove).
 		WithBody(req)
 
 	if len(req.ElasticsearchClusters) > 0 {

--- a/pkg/api/platformapi/allocatorapi/vacate_params.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_params.go
@@ -226,4 +226,5 @@ type PlanOverrides struct {
 	SkipSnapshot      *bool
 	SkipDataMigration *bool
 	OverrideFailsafe  *bool
+	ForceMove         *bool
 }

--- a/pkg/api/platformapi/allocatorapi/vacate_params.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_params.go
@@ -51,7 +51,7 @@ var (
 )
 
 // VacateParams used to vacate N allocators or clusters.
-//nolint
+// nolint
 type VacateParams struct {
 	*api.API
 
@@ -97,6 +97,9 @@ type VacateParams struct {
 	// Optional value to be set to keep the cluster in its current -possibly broken- state and just does the
 	// bare minimum to move the requested instances across to another allocator.
 	MoveOnly *bool
+
+	// Optional value to be set to force_move to true for primitive vacate or false for standard.
+	ForceMove *bool
 
 	// SkipTracking skips displaying and waiting for the individual vacates to complete.
 	// Setting it to true will render the concurrency flag pretty much ineffective since
@@ -166,6 +169,7 @@ type VacateClusterParams struct {
 	TrackFrequency time.Duration
 	AllocatorDown  *bool
 	MoveOnly       *bool
+	ForceMove      *bool
 	Output         *output.Device
 	OutputFormat   string
 	MaxPollRetries uint8

--- a/pkg/api/platformapi/allocatorapi/vacate_params_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_params_test.go
@@ -211,6 +211,7 @@ func TestVacateClusterParamsValidate(t *testing.T) {
 		TrackFrequency time.Duration
 		AllocatorDown  *bool
 		MoveOnly       *bool
+		ForceMove      *bool
 		Output         *output.Device
 		OutputFormat   string
 		MaxPollRetries uint8

--- a/pkg/api/platformapi/allocatorapi/vacate_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_test.go
@@ -1295,13 +1295,11 @@ func Test_newMoveClusterParams(t *testing.T) {
 				Kind:          "elasticsearch",
 				Output:        output.NewDevice(new(bytes.Buffer)),
 				AllocatorDown: ec.Bool(false),
-				ForceMove:     ec.Bool(true),
 			}},
 			want: platform_infrastructure.NewMoveClustersByTypeParams().
 				WithAllocatorID("allocator-1").
 				WithClusterType(util.Elasticsearch).
 				WithAllocatorDown(ec.Bool(false)).
-				WithForceMove(ec.Bool(true)).
 				WithContext(api.WithRegion(context.Background(), "us-east-1")).
 				WithBody(&models.MoveClustersRequest{
 					ElasticsearchClusters: []*models.MoveElasticsearchClusterConfiguration{

--- a/pkg/api/platformapi/allocatorapi/vacate_test.go
+++ b/pkg/api/platformapi/allocatorapi/vacate_test.go
@@ -1295,11 +1295,13 @@ func Test_newMoveClusterParams(t *testing.T) {
 				Kind:          "elasticsearch",
 				Output:        output.NewDevice(new(bytes.Buffer)),
 				AllocatorDown: ec.Bool(false),
+				ForceMove:     ec.Bool(true),
 			}},
 			want: platform_infrastructure.NewMoveClustersByTypeParams().
 				WithAllocatorID("allocator-1").
 				WithClusterType(util.Elasticsearch).
 				WithAllocatorDown(ec.Bool(false)).
+				WithForceMove(ec.Bool(true)).
 				WithContext(api.WithRegion(context.Background(), "us-east-1")).
 				WithBody(&models.MoveClustersRequest{
 					ElasticsearchClusters: []*models.MoveElasticsearchClusterConfiguration{

--- a/pkg/models/elasticsearch_plan_control_configuration.go
+++ b/pkg/models/elasticsearch_plan_control_configuration.go
@@ -84,6 +84,9 @@ type ElasticsearchPlanControlConfiguration struct {
 	// If true (default: false), does not take (or require) a successful snapshot to be taken before performing any potentially destructive changes to this cluster
 	SkipSnapshot *bool `json:"skip_snapshot,omitempty"`
 
+	// If false (default: true), will run standard vacate
+	ForceMove *bool `json:"force_move,omitempty"`
+
 	// If false (the default), the cluster will perform a snapshot after a major version upgrade takes place
 	SkipSnapshotPostMajorUpgrade *bool `json:"skip_snapshot_post_major_upgrade,omitempty"`
 


### PR DESCRIPTION
## Description
Adds ForceMove parameter to vacate parametes, in order to choose primitive vacate or standard vacate 

## Related Issues

Rel: https://elasticco.atlassian.net/browse/INFRA-3057
Rel: https://elasticco.atlassian.net/browse/INFRA-2823

## Motivation and Context

When a vacate plan fails due to Primitive vacate failure ( with error `InfrastructureFailure:CopyDataFailure`), we want to be able to retry with Standad vacate instead of Primitive vacate from automation tools like Fleetctl in order to try to reduce the number of SDH issues created.

## How Has This Been Tested?

This has been tested locally from Fleetctl https://github.com/elastic/fleetctl/pull/195, testing the cloud-sdk-go changes with this line in go.mod `replace github.com/elastic/cloud-sdk-go => ../cloud-sdk-go` 

![image](https://github.com/user-attachments/assets/a9530086-47ac-492e-b68a-69eba0181598)


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
