### PR TITLE
Deployments search: Add support for `minimal_metadata` parameter.

### DIFF
--- a/.changelog/1.24.0/495.yml
+++ b/.changelog/1.24.0/495.yml
@@ -1,0 +1,4 @@
+category: enhancement
+title: Add support for `MinimalMetadata` in the deployments search API.
+description: |
+  The new `MinimalMetadata` parameter allows returning only the specified fields in the response.

--- a/pkg/api/deploymentapi/search.go
+++ b/pkg/api/deploymentapi/search.go
@@ -20,6 +20,8 @@ package deploymentapi
 import (
 	"context"
 	"errors"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
+	"strings"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
 	"github.com/elastic/cloud-sdk-go/pkg/api/apierror"
@@ -32,8 +34,9 @@ import (
 type SearchParams struct {
 	*api.API
 
-	Context context.Context
-	Request *models.SearchRequest
+	Context         context.Context
+	Request         *models.SearchRequest
+	MinimalMetadata *[]string
 }
 
 // Validate ensures the parameters are usable by Shutdown.
@@ -56,10 +59,16 @@ func Search(params SearchParams) (*models.DeploymentsSearchResponse, error) {
 		return nil, err
 	}
 
+	requestParams := deployments.NewSearchDeploymentsParams().
+		WithBody(params.Request).
+		WithContext(params.Context)
+
+	if params.MinimalMetadata != nil {
+		requestParams.SetMinimalMetadata(ec.String(strings.Join(*params.MinimalMetadata, ",")))
+	}
+
 	res, err := params.V1API.Deployments.SearchDeployments(
-		deployments.NewSearchDeploymentsParams().
-			WithBody(params.Request).
-			WithContext(params.Context),
+		requestParams,
 		params.AuthWriter,
 	)
 	if err != nil {

--- a/pkg/api/deploymentapi/search.go
+++ b/pkg/api/deploymentapi/search.go
@@ -36,7 +36,7 @@ type SearchParams struct {
 
 	Context         context.Context
 	Request         *models.SearchRequest
-	MinimalMetadata *[]string
+	MinimalMetadata []string
 }
 
 // Validate ensures the parameters are usable by Shutdown.
@@ -63,8 +63,8 @@ func Search(params SearchParams) (*models.DeploymentsSearchResponse, error) {
 		WithBody(params.Request).
 		WithContext(params.Context)
 
-	if params.MinimalMetadata != nil {
-		requestParams.SetMinimalMetadata(ec.String(strings.Join(*params.MinimalMetadata, ",")))
+	if len(params.MinimalMetadata) > 0 {
+		requestParams.SetMinimalMetadata(ec.String(strings.Join(params.MinimalMetadata, ",")))
 	}
 
 	res, err := params.V1API.Deployments.SearchDeployments(

--- a/pkg/api/deploymentapi/search.go
+++ b/pkg/api/deploymentapi/search.go
@@ -20,7 +20,6 @@ package deploymentapi
 import (
 	"context"
 	"errors"
-	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 	"strings"
 
 	"github.com/elastic/cloud-sdk-go/pkg/api"
@@ -28,6 +27,7 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/client/deployments"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
+	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 )
 
 // SearchParams is consumed by Search.

--- a/pkg/api/deploymentapi/search_test.go
+++ b/pkg/api/deploymentapi/search_test.go
@@ -114,7 +114,7 @@ func TestSearch(t *testing.T) {
 }`),
 				)),
 				Request:         &models.SearchRequest{},
-				MinimalMetadata: &[]string{"id", "name"},
+				MinimalMetadata: []string{"id", "name"},
 			}},
 			want: &models.DeploymentsSearchResponse{
 				ReturnCount: ec.Int32(2),


### PR DESCRIPTION
This parameter will change the response to only include the passed in fields.

This is very useful as by default the response contains all deployment-related fields leading to quite large responses. If one only needs a few fields like the id, the `minimal_metadata` field can greatly reduce the response size.

<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
