### PR TITLE
fix(client_runtime): allow get-platform request to have regionless runtime

### DIFF
--- a/pkg/api/platformapi/info.go
+++ b/pkg/api/platformapi/info.go
@@ -25,7 +25,6 @@ import (
 	"github.com/elastic/cloud-sdk-go/pkg/client/platform"
 	"github.com/elastic/cloud-sdk-go/pkg/models"
 	"github.com/elastic/cloud-sdk-go/pkg/multierror"
-	"github.com/elastic/cloud-sdk-go/pkg/util/ec"
 )
 
 // GetInfoParams params is consumed by GetInfo
@@ -36,13 +35,9 @@ type GetInfoParams struct {
 
 // Validate ensures that the parameters are consumable by GetInfo.
 func (params GetInfoParams) Validate() error {
-	var merr = multierror.NewPrefixed("invalid platform get params")
+	merr := multierror.NewPrefixed("invalid platform get params")
 	if params.API == nil {
 		merr = merr.Append(apierror.ErrMissingAPI)
-	}
-
-	if err := ec.RequireRegionSet(params.Region); err != nil {
-		merr = merr.Append(err)
 	}
 
 	return merr.ErrorOrNil()


### PR DESCRIPTION
## Description
* the get-platform operation can be called in a region bound context and also in a region less context.
* the main use case of calling it regionless is to discover regions

## Related Issues

## Motivation and Context
The platform capacity team intends to move fully away of the internal-cloud-sdk-go and so far we were blocked by the GetPlatform call not be available in the regionless context. This is used to discover all cloud regions (https://github.com/elastic/internal-cloud-sdk-go/blob/master/pkg/api/platformapi/info.go)  

## How Has This Been Tested?
* extended test coverage
* used in [elastic/jit](https://github.com/elastic/jit) autoscaling

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
