### PR TITLE
ci: declare explicit least-privilege permissions for Go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,9 @@ name: Go
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:
@@ -33,7 +36,7 @@ jobs:
     - name: Linters
       run: make lint
       id: lint
-    
+
     - name: Run unit tests
       run: make unit
       id: unit


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` block to go.yml to make the GITHUB_TOKEN permissions explicit. This Pr is opened in the context of elastic/cp-hosted-team#4357.

## Types of Changes
- [x] Refactoring (improves code quality but has no user-facing effect)

## Readiness Checklist
- [x] My code follows the code style of this project
- [ ] I have added tests to cover my changes: To the best of my knowledge, Github actions first need to be merged to `master` so that Github picks them up.